### PR TITLE
[WIP] Adding opt-in support for non-standard (other than dbo) schemas

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -171,6 +171,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Volatile\When_sending_to_non_durable_endpoint.cs" />
     <Compile Include="When_scaling_out_senders_that_uses_callbacks.cs" />
+    <Compile Include="When_using_non_standard_schema.cs" />
     <Compile Include="When_sharing_the_receive_connection.cs" />
     <Compile Include="When_publishing_an_event_with_the_subscriber_scaled_out.cs" />
   </ItemGroup>

--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_using_non_standard_schema.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_using_non_standard_schema.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Config;
+    using NServiceBus.Config.ConfigurationSource;
+    using NUnit.Framework;
+
+    public class When_using_non_standard_schema : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) => bus.Send<MyMessage>(m=>
+                    {
+                        m.Id = context.Id;
+                    })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Repeat(r =>r.For(Serializers.Binary))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public Guid Id { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(x => x.UseTransport<SqlServerTransport>().UseSchema("sender").EnableSchemaAwareAddressing(true));
+            }
+
+            public class ConfigureMapping : IProvideConfiguration<UnicastBusConfig>
+            {
+                public UnicastBusConfig GetConfiguration()
+                {
+                    return new UnicastBusConfig()
+                    {
+                        MessageEndpointMappings = new MessageEndpointMappingCollection()
+                        {
+                            new MessageEndpointMapping()
+                            {
+                                AssemblyName = typeof(MyMessage).Assembly.FullName,
+                                TypeFullName = typeof(MyMessage).FullName,
+                                Endpoint = "receiver.Basic.Receiver.WhenUsingNonStandardSchema.Binary"
+                            }
+                        }
+                    };
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(x => x.UseTransport<SqlServerTransport>().UseSchema("receiver"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    if (Context.Id != message.Id)
+                    {
+                        return;
+                    }
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServer.cs
+++ b/src/NServiceBus.SqlServer/SqlServer.cs
@@ -9,7 +9,10 @@ namespace NServiceBus
     /// </summary>
     public class SqlServerTransport : TransportDefinition
     {
-        internal SqlServerTransport()
+        /// <summary>
+        /// 
+        /// </summary>
+        public SqlServerTransport()
         {
             RequireOutboxConsent = true;
         }

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -5,10 +5,16 @@ namespace NServiceBus.Transports.SQLServer
 
     class SqlServerQueueCreator : ICreateQueues
     {
-        const string Ddl =
-            @"IF NOT  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[{0}]') AND type in (N'U'))
+        const string SchemaDdl = 
+@"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{0}')
+BEGIN
+    EXEC('CREATE SCHEMA {0}');
+END";
+
+        const string TableDdl =
+            @"IF NOT  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{0}') AND type in (N'U'))
                   BEGIN
-                    CREATE TABLE [dbo].[{0}](
+                    CREATE TABLE {0}(
 	                    [Id] [uniqueidentifier] NOT NULL,
 	                    [CorrelationId] [varchar](255) NULL,
 	                    [ReplyToAddress] [varchar](255) NULL,
@@ -19,7 +25,7 @@ namespace NServiceBus.Transports.SQLServer
 	                    [RowVersion] [bigint] IDENTITY(1,1) NOT NULL
                     ) ON [PRIMARY];                    
 
-                    CREATE CLUSTERED INDEX [Index_RowVersion] ON [dbo].[{0}] 
+                    CREATE CLUSTERED INDEX [Index_RowVersion] ON {0} 
                     (
 	                    [RowVersion] ASC
                     )WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
@@ -30,16 +36,44 @@ namespace NServiceBus.Transports.SQLServer
         {
             using (var connection = new SqlConnection(ConnectionString))
             {
-                var sql = string.Format(Ddl, TableNameUtils.GetTableName(address));
                 connection.Open();
-
-                using (var command = new SqlCommand(sql, connection) {CommandType = CommandType.Text})
+                using (var transaction = connection.BeginTransaction())
                 {
-                    command.ExecuteNonQuery();
+                    if (SchemaName != null)
+                    {
+                        EnsureSchemaExists(connection, transaction);
+                    }
+                    EnsureTableExists(address, connection, transaction);
+                    transaction.Commit();
                 }
             }
         }
 
+        void EnsureTableExists(Address address, SqlConnection connection, SqlTransaction transaction)
+        {
+            var sql = string.Format(TableDdl, address.Queue.GetTableName(SchemaName ?? "dbo"));
+            ExecuteCommand(connection, transaction, sql);
+        }
+
+        void EnsureSchemaExists(SqlConnection connection, SqlTransaction transaction)
+        {
+            var sql = string.Format(SchemaDdl, SchemaName);
+            ExecuteCommand(connection, transaction, sql);
+        }
+
+        static void ExecuteCommand(SqlConnection connection, SqlTransaction transaction, string sql)
+        {
+            using (var command = new SqlCommand(sql, connection)
+            {
+                Transaction = transaction,
+                CommandType = CommandType.Text
+            })
+            {
+                command.ExecuteNonQuery();
+            }
+        }
+
         public string ConnectionString { get; set; }
+        public string SchemaName { get; set; }
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Configuration.AdvanceExtensibility;
+    using NServiceBus.Config;
 
     /// <summary>
     /// Adds extra configuration for the Sql Server transport.
@@ -33,6 +34,38 @@
                 throw new ArgumentException("Maximum concurrency value must be greater than zero.","maxConcurrency");
             }
             transportExtensions.GetSettings().Set(Features.SqlServerTransport.MaxConcurrencyForCallbackReceiverSettingKey, maxConcurrency);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Overrides the default (dbo) schema to use when creating and accessing queue tables.
+        /// If the schema does not exist it will be created when installing the host.
+        /// In order to be able to send messages to endpoints that use non-default schema, the sending endpoints need to enable schema-aware addressing <see cref="EnableSchemaAwareAddressing"/>
+        /// and prefix the endpoint queue table name with appropriate schema e.g. nsb.SomeEndpoint
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="schemaName">The name of the schema to use e.g. nsb</param>
+        /// <returns></returns>
+        public static TransportExtensions<SqlServerTransport> UseSchema(this TransportExtensions<SqlServerTransport> transportExtensions, string schemaName)
+        {
+            if (string.IsNullOrWhiteSpace(schemaName))
+            {
+                throw new ArgumentException("Schema name must be a non-empty string.");
+            }
+            transportExtensions.GetSettings().Set(Features.SqlServerTransport.SchemaName, schemaName);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Enables addressing mode that is schema-aware. When enabled, endpoint addresses in message mappings (<see cref="UnicastBusConfig"/>)
+        /// need to be in form "schema.table.name" where part before the first dot denotes the schema.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="enable">Enable?</param>
+        /// <returns></returns>
+        public static TransportExtensions<SqlServerTransport> EnableSchemaAwareAddressing(this TransportExtensions<SqlServerTransport> transportExtensions, bool enable)
+        {
+            transportExtensions.GetSettings().Set(Features.SqlServerTransport.SchemaAwareAddressing, enable);
             return transportExtensions;
         }
     }

--- a/src/NServiceBus.SqlServer/TableNameUtils.cs
+++ b/src/NServiceBus.SqlServer/TableNameUtils.cs
@@ -6,19 +6,36 @@ namespace NServiceBus.Transports.SQLServer
 
     static class TableNameUtils
     {
-        public static string GetTableName(this Address address)
+        public static string GetTableName(this Address address, bool schemaAwareAddressing)
         {
-            return GetTableName(address.Queue);
-        }
-        
-        public static string GetTableName(this string queueName)
-        {
-            if (queueName.Length > 128)
+            if (!schemaAwareAddressing)
             {
-                return DeterministicGuidBuilder(queueName).ToString();
+                return GetTableName(address.Queue, null);
             }
+            var parts = address.Queue.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2)
+            {
+                throw new InvalidOperationException("When schema-aware addressing is enabled, addresses in message-endpoint mappings must include schema name e.g. dbo.SomeEndpoint.");
+            }
+            var queueName = address.Queue.Substring(address.Queue.IndexOf(".", StringComparison.Ordinal) + 1);
+            var schemaName = parts[0];
+            return GetTableName(queueName, schemaName);
+        }
 
-            return queueName;
+        //public static string GetTableName(this Address address, string schemaName)
+        //{
+        //    return GetTableName(address.Queue, schemaName);
+        //}
+        
+        public static string GetTableName(this string queueName, string schemaName)
+        {
+            var tableName = queueName.Length > 128 
+                ? DeterministicGuidBuilder(queueName).ToString() 
+                : queueName;
+
+            return schemaName != null
+                ? "[" + schemaName + "].[" + tableName + "]"
+                : "[" + tableName + "]";
         }
 
         private static Guid DeterministicGuidBuilder(string input)


### PR DESCRIPTION
Usage
- UseSchema("someSchema") to specify in which schema should the tables be created
- EnableSchemaAwareAddressing(true) to specify that addresses in message-endpoint mappings contain schema information (required to be able to send to non-default-schema endpoints)

I thought about using machine name part of address for schema but it seems like if I don't specify machine in mappings, it is set to local machine name.

@johnsimons can you take a look?
