### PR TITLE
WIP - Using the endpoint address for determining the connection string instead of callback address

### DIFF
--- a/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
+++ b/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
@@ -51,9 +51,9 @@
             {
                 //If there is a connectionstring configured for the queue, use that connectionstring
                 var queueConnectionString = DefaultConnectionString;
-                if (ConnectionStringCollection.Keys.Contains(queue))
+                if (ConnectionStringCollection.Keys.Contains(sendOptions.Destination.Queue))
                 {
-                    queueConnectionString = ConnectionStringCollection[queue];
+                    queueConnectionString = ConnectionStringCollection[sendOptions.Destination.Queue];
                 }
 
                 if (sendOptions.EnlistInReceiveTransaction)


### PR DESCRIPTION
DO NOT MERGE - Creating the PR to trigger the acceptance tests! 
-- Relates to #59

**Things to do**
- [x] Add additional databases (NServiceBus1 and NServiceBus2) in the build server agent to facilitate acceptance tests
- [ ] Add acceptance tests for this feature
- [ ] Make sure all the other acceptance tests pass with this fix
