### PR TITLE
SqlConnections should be created with factory 

### DIFF
--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ConnectionConfigTests.cs" />
     <Compile Include="ErrorQueueSettingsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlConnectionFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NServiceBus.snk" />

--- a/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryTests.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+
+namespace NServiceBus.SqlServer.UnitTests
+{
+    using System;
+    using NServiceBus.Transports.SQLServer;
+    using NServiceBus.Transports.SQLServer.Config;
+
+    [TestFixture]
+    public class SqlConnectionFactoryTests
+    {
+        [Test]
+        public void Empty_Class_Name_Leads_To_Null_Factory()
+        {
+            var factoryInstance = SqlConnectionFactory.ConnectionFactoryInstance("");
+            Assert.IsNull(factoryInstance);
+        }
+
+        [Test]
+        public void Null_Class_Name_Leads_To_Null_Factory()
+        {
+            var factoryInstance = SqlConnectionFactory.ConnectionFactoryInstance(null);
+            Assert.IsNull(factoryInstance);
+        }
+
+        [Test]
+        public void Non_Existing_Class_Name_Leads_To_Exception()
+        {
+            Assert.Throws<TypeLoadException>(() => SqlConnectionFactory.ConnectionFactoryInstance("NServiceBus.SqlServer.UnitTests.ClassThatDoesNotExists, NServiceBus.SqlServer.UnitTests"));
+        }
+
+        [Test]
+        public void Class_That_Does_Not_Implement_ISqlConnectionFactory_Leads_To_Exception()
+        {
+            Assert.Throws<ArgumentException>(() => SqlConnectionFactory.ConnectionFactoryInstance("NServiceBus.SqlServer.UnitTests.SqlConnectionFactoryTests, NServiceBus.SqlServer.UnitTests"));
+        }
+
+        [Test]
+        public void Class_That_Implements_ISqlConnectionFactory_Works_Ok()
+        {
+            Assert.IsNotNull(SqlConnectionFactory.ConnectionFactoryInstance("NServiceBus.Transports.SQLServer.DefaultSqlConnectionFactory, NServiceBus.Transports.SQLServer"));
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
@@ -31,9 +31,8 @@ namespace NServiceBus.Transports.SQLServer
         {
             using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions))
             {
-                using (var connection = new SqlConnection(connectionString))
+                using (var connection = SqlConnectionFactory.OpenNewConnection(connectionString))
                 {
-                    connection.Open();
                     using (pipelineExecutor.SetConnection(connectionString, connection))
                     {
                         var readResult = queue.TryReceive(connection);

--- a/src/NServiceBus.SqlServer/DefaultSqlConnectionFactory.cs
+++ b/src/NServiceBus.SqlServer/DefaultSqlConnectionFactory.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+
+    /// <summary>
+    /// Default implementation of SQL connections factory.
+    /// </summary>
+    public class DefaultSqlConnectionFactory : ISqlConnectionFactory
+    {
+        /// <summary>
+        /// Creates new SqlConnection instances and opens connections.
+        /// </summary>
+        public SqlConnection OpenNewConnection(string connectionString)
+        {
+            var connection = new SqlConnection(connectionString);
+
+            try
+            {
+                connection.Open();
+            }
+            catch (Exception)
+            {
+                connection.Dispose();
+                throw;
+            }
+
+            return connection;
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/ISqlConnectionFactory.cs
+++ b/src/NServiceBus.SqlServer/ISqlConnectionFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System.Data.SqlClient;
+
+    /// <summary>
+    /// Factory of SQL connections.
+    /// </summary>
+    public interface ISqlConnectionFactory
+    {
+        /// <summary>
+        /// Creates new SqlConnection instance and opens it.
+        /// </summary>
+        SqlConnection OpenNewConnection(string connectionString);
+    }
+}

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -77,6 +77,9 @@
     <Compile Include="Config\ConfigBase.cs" />
     <Compile Include="Config\ConnectionConfig.cs" />
     <Compile Include="Config\PurgingConfig.cs" />
+    <Compile Include="DefaultSqlConnectionFactory.cs" />
+    <Compile Include="ISqlConnectionFactory.cs" />
+    <Compile Include="SqlConnectionFactory.cs" />
     <Compile Include="Config\ValidateOutboxOrAmbientTransactionsEnabled.cs" />
     <Compile Include="ConnectionInfo.cs" />
     <Compile Include="ConnectionParams.cs" />

--- a/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
@@ -25,9 +25,8 @@ namespace NServiceBus.Transports.SQLServer
 
         public ReceiveResult TryReceiveFrom(TableBasedQueue queue)
         {
-            using (var connection = new SqlConnection(connectionString))
+            using (var connection = SqlConnectionFactory.OpenNewConnection(connectionString))
             {
-                connection.Open();
                 using (pipelineExecutor.SetConnection(connectionString, connection))
                 {
                     using (var transaction = connection.BeginTransaction(isolationLevel))

--- a/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
@@ -19,9 +19,8 @@ namespace NServiceBus.Transports.SQLServer
         public ReceiveResult TryReceiveFrom(TableBasedQueue queue)
         {
             MessageReadResult readResult;
-            using (var connection = new SqlConnection(connectionString))
+            using (var connection = SqlConnectionFactory.OpenNewConnection(connectionString))
             {
-                connection.Open();
                 readResult = queue.TryReceive(connection);
                 if (readResult.IsPoison)
                 {

--- a/src/NServiceBus.SqlServer/QueuePurger.cs
+++ b/src/NServiceBus.SqlServer/QueuePurger.cs
@@ -23,10 +23,8 @@ namespace NServiceBus.Transports.SQLServer
 
         void Purge(IEnumerable<string> tableNames)
         {
-            using (var connection = new SqlConnection(localConnectionParams.ConnectionString))
+            using (var connection = SqlConnectionFactory.OpenNewConnection(localConnectionParams.ConnectionString))
             {
-                connection.Open();
-
                 foreach (var tableName in tableNames)
                 {
                     using (var command = new SqlCommand(string.Format(SqlPurge, localConnectionParams.Schema, tableName), connection)

--- a/src/NServiceBus.SqlServer/SqlConnectionFactory.cs
+++ b/src/NServiceBus.SqlServer/SqlConnectionFactory.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Configuration;
+
+    /// <summary>
+    /// Factory for new SQL connections. Can be configured using 
+    /// <appSettings>
+    ///   <add key="NServiceBus/Transport/SQLServer/connection.factory" value="NServiceBus.Transports.SQLServer.DefaultSqlConnectionFactory, NServiceBus.Transports.SQLServer"/>
+    /// </appSettings>
+    /// </summary>
+    public static class SqlConnectionFactory
+    {
+        static ISqlConnectionFactory sqlConnectionFactory;
+        private static object lockObj = new object();
+
+
+        /// <summary>
+        /// Creates instance of ISQLConnectionFactory from factory class name.
+        /// </summary><param name="factoryClass">Assembly Qualified class name.</param>
+        public static ISqlConnectionFactory ConnectionFactoryInstance(string factoryClass)
+        {
+            if (string.IsNullOrEmpty(factoryClass))
+                return null;
+
+            var factoryType = Type.GetType(factoryClass);
+            if (factoryType == null)
+                throw new TypeLoadException("Cannot load type " + factoryClass);
+
+            var factoryInstance = Activator.CreateInstance(factoryType) as ISqlConnectionFactory;
+
+            if (factoryInstance == null)
+                throw new ArgumentException("Type " + factoryClass + " does not implement interface ISqlConnectionFactory.");
+
+            return factoryInstance;
+        }
+
+        private static ISqlConnectionFactory ConfiguredConnectionFactory()
+        {
+            return ConnectionFactoryInstance(ConfigurationManager.AppSettings[@"NServiceBus/Transport/SQLServer/connection.factory"]);
+        }
+
+        private static void InitFactory()
+        {
+            if (sqlConnectionFactory != null)
+                return;
+            lock (lockObj)
+            {
+                if (sqlConnectionFactory != null)
+                    return;
+
+                var configuredFactory = ConfiguredConnectionFactory();
+                sqlConnectionFactory = configuredFactory ?? new DefaultSqlConnectionFactory();
+            }
+        }
+
+        /// <summary>
+        /// Creates and opens new SQL connections.
+        /// </summary><param name="connectionString">Database connection string.</param>
+        public static SqlConnection OpenNewConnection(string connectionString)
+        {
+            InitFactory();
+
+            var connection = sqlConnectionFactory.OpenNewConnection(connectionString);
+            if (connection.State != ConnectionState.Open)
+            {
+                connection.Dispose();
+                throw new Exception("Connections created by SqlConnectionFactory should be Open.");
+            }
+
+            return connection;
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
+++ b/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
@@ -43,9 +43,8 @@
                         }
                         else
                         {
-                            using (var connection = new SqlConnection(connectionInfo.ConnectionString))
+                            using (var connection = SqlConnectionFactory.OpenNewConnection(connectionInfo.ConnectionString))
                             {
-                                connection.Open();
                                 queue.Send(message, sendOptions, connection);
                             }
                         }
@@ -56,9 +55,8 @@
                     // Suppress so that even if DTC is on, we won't escalate
                     using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
                     {
-                        using (var connection = new SqlConnection(connectionInfo.ConnectionString))
+                        using (var connection = SqlConnectionFactory.OpenNewConnection(connectionInfo.ConnectionString))
                         {
-                            connection.Open();
                             queue.Send(message, sendOptions, connection);
                         }
 

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -29,10 +29,9 @@ namespace NServiceBus.Transports.SQLServer
         public void CreateQueueIfNecessary(Address address, string account)
         {
             var connectionParams = connectionStringProvider.GetForDestination(address);
-            using (var connection = new SqlConnection(connectionParams.ConnectionString))
+            using (var connection = SqlConnectionFactory.OpenNewConnection(connectionParams.ConnectionString))
             {
                 var sql = string.Format(Ddl, connectionParams.Schema, address.GetTableName());
-                connection.Open();
 
                 using (var command = new SqlCommand(sql, connection) {CommandType = CommandType.Text})
                 {


### PR DESCRIPTION
*Make usage of NHibernate compatible with `SET NOCOUNT ON` DB-wide setting #112* issue shows how NOCOUNT server setting can break the NHibernate persistence. It was solved by injecting NHibernate's DriverConnectionProvider, that fixes connections immediately after their opening. However, when SQL Server transport is used, and the same database is used for Timeouts persistence and SQL Transport, it can happen that connections opened for transport can be used by Timeouts persistence routines.

Solution: allow injection of custom SQL connections' factories, like NHibernate does. Such factories can, for example, send `SET NOCOUNT OFF` command immediately after opening the connection.