### PR TITLE
SqlConnections should be created with factory

### DIFF
--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ConnectionConfigTests.cs" />
     <Compile Include="ErrorQueueSettingsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlConnectionFactoryConfigTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NServiceBus.snk" />

--- a/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryConfigTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryConfigTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Data.SqlClient;
     using System.Reflection;
+    using NServiceBus.Transports.SQLServer;
     using NServiceBus.Transports.SQLServer.Config;
     using NUnit.Framework;
 
@@ -18,10 +19,10 @@
             busConfig.UseTransport<SqlServerTransport>();
 
             var builder = Activate(busConfig, new SqlConnectionFactoryConfig());
-            var factory = builder.Build<Func<string, SqlConnection>>();
+            var factory = builder.Build<CustomSqlConnectionFactory>();
 
             Assert.IsNotNull(factory);
-            Assert.AreEqual(defaultFactoryMethod, factory.Method);
+            Assert.AreEqual(defaultFactoryMethod, factory.OpenNewConnection.Method);
         }
 
         [Test]
@@ -35,10 +36,10 @@
                 .UseCustomSqlConnectionFactory(testFactory);
 
             var builder = Activate(busConfig, new SqlConnectionFactoryConfig());
-            var factory = builder.Build<Func<string, SqlConnection>>();
+            var factory = builder.Build<CustomSqlConnectionFactory>();
 
             Assert.IsNotNull(factory);
-            Assert.AreEqual(factory, testFactory);
+            Assert.AreEqual(testFactory, factory.OpenNewConnection);
         }
     }
 }

--- a/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryConfigTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/SqlConnectionFactoryConfigTests.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.SqlServer.UnitTests
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Reflection;
+    using NServiceBus.Transports.SQLServer.Config;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class SqlConnectionFactoryConfigTests : ConfigTest
+    {
+        [Test]
+        public void sql_connection_factory_exists_by_default()
+        {
+            var defaultFactoryMethod = typeof(SqlConnectionFactoryConfig).GetMethod("DefaultOpenNewConnection", BindingFlags.Static | BindingFlags.NonPublic);
+
+            var busConfig = new BusConfiguration();
+            busConfig.UseTransport<SqlServerTransport>();
+
+            var builder = Activate(busConfig, new SqlConnectionFactoryConfig());
+            var factory = builder.Build<Func<string, SqlConnection>>();
+
+            Assert.IsNotNull(factory);
+            Assert.AreEqual(defaultFactoryMethod, factory.Method);
+        }
+
+        [Test]
+        public void sql_connection_factory_can_be_customized()
+        {
+            Func<string, SqlConnection> testFactory = connectionString => { throw new Exception("Error"); };
+
+            var busConfig = new BusConfiguration();
+            busConfig
+                .UseTransport<SqlServerTransport>()
+                .UseCustomSqlConnectionFactory(testFactory);
+
+            var builder = Activate(busConfig, new SqlConnectionFactoryConfig());
+            var factory = builder.Build<Func<string, SqlConnection>>();
+
+            Assert.IsNotNull(factory);
+            Assert.AreEqual(factory, testFactory);
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transports.SQLServer
 {
     using System;
-    using System.Data.SqlClient;
     using System.Transactions;
     using NServiceBus.Pipeline;
     using NServiceBus.Unicast.Transport;

--- a/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/AmbientTransactionReceiveStrategy.cs
@@ -13,9 +13,9 @@ namespace NServiceBus.Transports.SQLServer
         readonly TableBasedQueue errorQueue;
         readonly Func<TransportMessage, bool> tryProcessMessageCallback;
         readonly TransactionOptions transactionOptions;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public AmbientTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, Func<string, SqlConnection> sqlConnectionFactory, PipelineExecutor pipelineExecutor, TransactionSettings transactionSettings)
+        public AmbientTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, CustomSqlConnectionFactory sqlConnectionFactory, PipelineExecutor pipelineExecutor, TransactionSettings transactionSettings)
         {
             this.pipelineExecutor = pipelineExecutor;
             this.tryProcessMessageCallback = tryProcessMessageCallback;
@@ -34,7 +34,7 @@ namespace NServiceBus.Transports.SQLServer
         {
             using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions))
             {
-                using (var connection = sqlConnectionFactory(connectionString))
+                using (var connection = sqlConnectionFactory.OpenNewConnection(connectionString))
                 {
                     using (pipelineExecutor.SetConnection(connectionString, connection))
                     {

--- a/src/NServiceBus.SqlServer/Config/SqlConnectionFactoryConfig.cs
+++ b/src/NServiceBus.SqlServer/Config/SqlConnectionFactoryConfig.cs
@@ -28,14 +28,13 @@
 
         public override void SetUpDefaults(SettingsHolder settings)
         {
-            Func<string, SqlConnection> factoryMethod = DefaultOpenNewConnection;
-            settings.SetDefault(CustomSqlConnectionFactorySettingKey, factoryMethod);
+            settings.SetDefault(CustomSqlConnectionFactorySettingKey, new CustomSqlConnectionFactory(DefaultOpenNewConnection));
         }
 
         public override void Configure(FeatureConfigurationContext context, string connectionStringWithSchema)
         {
-            var factoryMethod = (Func<string, SqlConnection>)context.Settings.Get(CustomSqlConnectionFactorySettingKey);
-            context.Container.ConfigureComponent(b => factoryMethod, DependencyLifecycle.SingleInstance);
+            var factory = (CustomSqlConnectionFactory)context.Settings.Get(CustomSqlConnectionFactorySettingKey);
+            context.Container.ConfigureComponent(b => factory, DependencyLifecycle.SingleInstance);
         }
     }
 }

--- a/src/NServiceBus.SqlServer/Config/SqlConnectionFactoryConfig.cs
+++ b/src/NServiceBus.SqlServer/Config/SqlConnectionFactoryConfig.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Transports.SQLServer.Config
+{
+    using System;
+    using System.Data.SqlClient;
+    using NServiceBus.Features;
+    using NServiceBus.Settings;
+
+    class SqlConnectionFactoryConfig : ConfigBase
+    {
+        internal const string CustomSqlConnectionFactorySettingKey = "SqlServer.CustomSqlConnectionFactory";
+
+        static SqlConnection DefaultOpenNewConnection(string connectionString)
+        {
+            var connection = new SqlConnection(connectionString);
+
+            try
+            {
+                connection.Open();
+            }
+            catch (Exception)
+            {
+                connection.Dispose();
+                throw;
+            }
+
+            return connection;
+        }
+
+        public override void SetUpDefaults(SettingsHolder settings)
+        {
+            Func<string, SqlConnection> factoryMethod = DefaultOpenNewConnection;
+            settings.SetDefault(CustomSqlConnectionFactorySettingKey, factoryMethod);
+        }
+
+        public override void Configure(FeatureConfigurationContext context, string connectionStringWithSchema)
+        {
+            var factoryMethod = (Func<string, SqlConnection>)context.Settings.Get(CustomSqlConnectionFactorySettingKey);
+            context.Container.ConfigureComponent(b => factoryMethod, DependencyLifecycle.SingleInstance);
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
+++ b/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
@@ -64,7 +64,7 @@ namespace NServiceBus.Features
             context.Container.ConfigureComponent<SqlServerQueueCreator>(DependencyLifecycle.InstancePerCall);
 
             var errorQueue = ErrorQueueSettings.GetConfiguredErrorQueue(context.Settings);
-            context.Container.ConfigureComponent(b => new ReceiveStrategyFactory(b.Build<PipelineExecutor>(), b.Build<LocalConnectionParams>(), errorQueue, b.Build<Func<string, SqlConnection>>()),  DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent(b => new ReceiveStrategyFactory(b.Build<PipelineExecutor>(), b.Build<LocalConnectionParams>(), errorQueue, b.Build<CustomSqlConnectionFactory>()), DependencyLifecycle.InstancePerCall);
 
             context.Container.ConfigureComponent<SqlServerPollingDequeueStrategy>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent<SqlServerStorageContext>(DependencyLifecycle.InstancePerUnitOfWork);

--- a/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
+++ b/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Features
     using System;
     using System.Collections.Generic;
     using System.Configuration;
+    using System.Data.SqlClient;
     using System.Linq;
     using NServiceBus.Transports.SQLServer.Config;
     using Pipeline;
@@ -18,7 +19,8 @@ namespace NServiceBus.Features
             new CallbackConfig(),
             new CircuitBreakerConfig(),
             new ConnectionConfig(ConfigurationManager.ConnectionStrings.Cast<ConnectionStringSettings>().ToList()),
-            new PurgingConfig()
+            new PurgingConfig(),
+            new SqlConnectionFactoryConfig()
         };
 
         public SqlServerTransportFeature()
@@ -62,7 +64,7 @@ namespace NServiceBus.Features
             context.Container.ConfigureComponent<SqlServerQueueCreator>(DependencyLifecycle.InstancePerCall);
 
             var errorQueue = ErrorQueueSettings.GetConfiguredErrorQueue(context.Settings);
-            context.Container.ConfigureComponent(b => new ReceiveStrategyFactory(b.Build<PipelineExecutor>(), b.Build<LocalConnectionParams>(), errorQueue),  DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent(b => new ReceiveStrategyFactory(b.Build<PipelineExecutor>(), b.Build<LocalConnectionParams>(), errorQueue, b.Build<Func<string, SqlConnection>>()),  DependencyLifecycle.InstancePerCall);
 
             context.Container.ConfigureComponent<SqlServerPollingDequeueStrategy>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent<SqlServerStorageContext>(DependencyLifecycle.InstancePerUnitOfWork);

--- a/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
+++ b/src/NServiceBus.SqlServer/Config/SqlServerTransportFeature.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Features
     using System;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.Data.SqlClient;
     using System.Linq;
     using NServiceBus.Transports.SQLServer.Config;
     using Pipeline;

--- a/src/NServiceBus.SqlServer/CustomSqlConnectionFactory.cs
+++ b/src/NServiceBus.SqlServer/CustomSqlConnectionFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+
+    class CustomSqlConnectionFactory
+    {
+        public readonly Func<string, SqlConnection> OpenNewConnection;
+
+        public CustomSqlConnectionFactory(Func<string, SqlConnection> factory)
+        {
+            this.OpenNewConnection = factory;
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/CustomSqlConnectionFactory.cs
+++ b/src/NServiceBus.SqlServer/CustomSqlConnectionFactory.cs
@@ -9,7 +9,7 @@
 
         public CustomSqlConnectionFactory(Func<string, SqlConnection> factory)
         {
-            this.OpenNewConnection = factory;
+            OpenNewConnection = factory;
         }
     }
 }

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -111,6 +111,7 @@
     <Compile Include="ReceiveTaskTracker.cs" />
     <Compile Include="SecondaryReceiveConfiguration.cs" />
     <Compile Include="SecondaryReceiveSettings.cs" />
+    <Compile Include="CustomSqlConnectionFactory.cs" />
     <Compile Include="SqlServerSettingsExtensions.cs" />
     <Compile Include="SqlServerStorageContext.cs" />
     <Compile Include="SqlServerTransport.cs" />

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Config\ConfigBase.cs" />
     <Compile Include="Config\ConnectionConfig.cs" />
     <Compile Include="Config\PurgingConfig.cs" />
+    <Compile Include="Config\SqlConnectionFactoryConfig.cs" />
     <Compile Include="Config\ValidateOutboxOrAmbientTransactionsEnabled.cs" />
     <Compile Include="ConnectionInfo.cs" />
     <Compile Include="ConnectionParams.cs" />

--- a/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
@@ -13,9 +13,9 @@ namespace NServiceBus.Transports.SQLServer
         readonly TableBasedQueue errorQueue;
         readonly Func<TransportMessage, bool> tryProcessMessageCallback;
         readonly IsolationLevel isolationLevel;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public NativeTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, Func<string, SqlConnection> sqlConnectionFactory, PipelineExecutor pipelineExecutor, TransactionSettings transactionSettings)
+        public NativeTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, CustomSqlConnectionFactory sqlConnectionFactory, PipelineExecutor pipelineExecutor, TransactionSettings transactionSettings)
         {
             this.pipelineExecutor = pipelineExecutor;
             this.tryProcessMessageCallback = tryProcessMessageCallback;
@@ -27,7 +27,7 @@ namespace NServiceBus.Transports.SQLServer
 
         public ReceiveResult TryReceiveFrom(TableBasedQueue queue)
         {
-            using (var connection = sqlConnectionFactory(connectionString))
+            using (var connection = sqlConnectionFactory.OpenNewConnection(connectionString))
             {
                 using (pipelineExecutor.SetConnection(connectionString, connection))
                 {

--- a/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NativeTransactionReceiveStrategy.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Transports.SQLServer
 {
     using System;
     using System.Data;
-    using System.Data.SqlClient;
     using NServiceBus.Pipeline;
     using NServiceBus.Unicast.Transport;
 

--- a/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
@@ -8,20 +8,21 @@ namespace NServiceBus.Transports.SQLServer
         readonly string connectionString;
         readonly TableBasedQueue errorQueue;
         readonly Func<TransportMessage, bool> tryProcessMessageCallback;
+        readonly Func<string, SqlConnection> sqlConnectionFactory;
 
-        public NoTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback)
+        public NoTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, Func<string, SqlConnection> sqlConnectionFactory)
         {
             this.connectionString = connectionString;
             this.errorQueue = errorQueue;
             this.tryProcessMessageCallback = tryProcessMessageCallback;
+            this.sqlConnectionFactory = sqlConnectionFactory;
         }
 
         public ReceiveResult TryReceiveFrom(TableBasedQueue queue)
         {
             MessageReadResult readResult;
-            using (var connection = new SqlConnection(connectionString))
+            using (var connection = sqlConnectionFactory(connectionString))
             {
-                connection.Open();
                 readResult = queue.TryReceive(connection);
                 if (readResult.IsPoison)
                 {

--- a/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transports.SQLServer
 {
     using System;
-    using System.Data.SqlClient;
 
     class NoTransactionReceiveStrategy : IReceiveStrategy
     {

--- a/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/NoTransactionReceiveStrategy.cs
@@ -8,9 +8,9 @@ namespace NServiceBus.Transports.SQLServer
         readonly string connectionString;
         readonly TableBasedQueue errorQueue;
         readonly Func<TransportMessage, bool> tryProcessMessageCallback;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public NoTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, Func<string, SqlConnection> sqlConnectionFactory)
+        public NoTransactionReceiveStrategy(string connectionString, TableBasedQueue errorQueue, Func<TransportMessage, bool> tryProcessMessageCallback, CustomSqlConnectionFactory sqlConnectionFactory)
         {
             this.connectionString = connectionString;
             this.errorQueue = errorQueue;
@@ -21,7 +21,7 @@ namespace NServiceBus.Transports.SQLServer
         public ReceiveResult TryReceiveFrom(TableBasedQueue queue)
         {
             MessageReadResult readResult;
-            using (var connection = sqlConnectionFactory(connectionString))
+            using (var connection = sqlConnectionFactory.OpenNewConnection(connectionString))
             {
                 readResult = queue.TryReceive(connection);
                 if (readResult.IsPoison)

--- a/src/NServiceBus.SqlServer/QueuePurger.cs
+++ b/src/NServiceBus.SqlServer/QueuePurger.cs
@@ -10,9 +10,9 @@ namespace NServiceBus.Transports.SQLServer
     class QueuePurger : IQueuePurger
     {
         readonly LocalConnectionParams localConnectionParams;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public QueuePurger(SecondaryReceiveConfiguration secondaryReceiveConfiguration, LocalConnectionParams localConnectionParams, Func<string, SqlConnection> sqlConnectionFactory)
+        public QueuePurger(SecondaryReceiveConfiguration secondaryReceiveConfiguration, LocalConnectionParams localConnectionParams, CustomSqlConnectionFactory sqlConnectionFactory)
         {
             this.secondaryReceiveConfiguration = secondaryReceiveConfiguration;
             this.localConnectionParams = localConnectionParams;
@@ -26,7 +26,7 @@ namespace NServiceBus.Transports.SQLServer
 
         void Purge(IEnumerable<string> tableNames)
         {
-            using (var connection = sqlConnectionFactory(localConnectionParams.ConnectionString))
+            using (var connection = sqlConnectionFactory.OpenNewConnection(localConnectionParams.ConnectionString))
             {
                 foreach (var tableName in tableNames)
                 {

--- a/src/NServiceBus.SqlServer/QueuePurger.cs
+++ b/src/NServiceBus.SqlServer/QueuePurger.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transports.SQLServer
 {
-    using System;
     using System.Collections.Generic;
     using System.Data;
     using System.Data.SqlClient;

--- a/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
+++ b/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
@@ -10,9 +10,9 @@ namespace NServiceBus.Transports.SQLServer
         readonly PipelineExecutor pipelineExecutor;
         readonly Address errorQueueAddress;
         readonly LocalConnectionParams localConnectionParams;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public ReceiveStrategyFactory(PipelineExecutor pipelineExecutor, LocalConnectionParams localConnectionParams, Address errorQueueAddress, Func<string, SqlConnection> sqlConnectionFactory)
+        public ReceiveStrategyFactory(PipelineExecutor pipelineExecutor, LocalConnectionParams localConnectionParams, Address errorQueueAddress, CustomSqlConnectionFactory sqlConnectionFactory)
         {
             this.pipelineExecutor = pipelineExecutor;
             this.errorQueueAddress = errorQueueAddress;

--- a/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
+++ b/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transports.SQLServer
 {
     using System;
+    using System.Data.SqlClient;
     using NServiceBus.Pipeline;
     using NServiceBus.Unicast.Transport;
 
@@ -9,26 +10,29 @@ namespace NServiceBus.Transports.SQLServer
         readonly PipelineExecutor pipelineExecutor;
         readonly Address errorQueueAddress;
         readonly LocalConnectionParams localConnectionParams;
+        readonly Func<string, SqlConnection> sqlConnectionFactory;
 
-        public ReceiveStrategyFactory(PipelineExecutor pipelineExecutor, LocalConnectionParams localConnectionParams, Address errorQueueAddress)
+        public ReceiveStrategyFactory(PipelineExecutor pipelineExecutor, LocalConnectionParams localConnectionParams, Address errorQueueAddress, Func<string, SqlConnection> sqlConnectionFactory)
         {
             this.pipelineExecutor = pipelineExecutor;
             this.errorQueueAddress = errorQueueAddress;
             this.localConnectionParams = localConnectionParams;
+            this.sqlConnectionFactory = sqlConnectionFactory;
         }
 
         public IReceiveStrategy Create(TransactionSettings settings, Func<TransportMessage, bool> tryProcessMessageCallback)
         {
             var errorQueue = new TableBasedQueue(errorQueueAddress, localConnectionParams.Schema);
+
             if (settings.IsTransactional)
             {
                 if (settings.SuppressDistributedTransactions)
                 {
-                    return new NativeTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback, pipelineExecutor, settings);
+                    return new NativeTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback, sqlConnectionFactory, pipelineExecutor, settings);
                 }
-                return new AmbientTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback, pipelineExecutor, settings);
+                return new AmbientTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback, sqlConnectionFactory, pipelineExecutor, settings);
             }
-            return new NoTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback);
+            return new NoTransactionReceiveStrategy(localConnectionParams.ConnectionString, errorQueue, tryProcessMessageCallback, sqlConnectionFactory);
         }
     }
 }

--- a/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
+++ b/src/NServiceBus.SqlServer/ReceiveStrategyFactory.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transports.SQLServer
 {
     using System;
-    using System.Data.SqlClient;
     using NServiceBus.Pipeline;
     using NServiceBus.Unicast.Transport;
 

--- a/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
+++ b/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
@@ -11,9 +11,9 @@
     {
         readonly IConnectionStringProvider connectionStringProvider;
         readonly PipelineExecutor pipelineExecutor;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public SqlServerMessageSender(IConnectionStringProvider connectionStringProvider, PipelineExecutor pipelineExecutor, Func<string, SqlConnection> sqlConnectionFactory)
+        public SqlServerMessageSender(IConnectionStringProvider connectionStringProvider, PipelineExecutor pipelineExecutor, CustomSqlConnectionFactory sqlConnectionFactory)
         {
             this.connectionStringProvider = connectionStringProvider;
             this.pipelineExecutor = pipelineExecutor;
@@ -45,7 +45,7 @@
                         }
                         else
                         {
-                            using (var connection = sqlConnectionFactory(connectionInfo.ConnectionString))
+                            using (var connection = sqlConnectionFactory.OpenNewConnection(connectionInfo.ConnectionString))
                             {
                                 queue.Send(message, sendOptions, connection);
                             }
@@ -57,7 +57,7 @@
                     // Suppress so that even if DTC is on, we won't escalate
                     using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
                     {
-                        using (var connection = sqlConnectionFactory(connectionInfo.ConnectionString))
+                        using (var connection = sqlConnectionFactory.OpenNewConnection(connectionInfo.ConnectionString))
                         {
                             queue.Send(message, sendOptions, connection);
                         }

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transports.SQLServer
 {
+    using System;
     using System.Data;
     using System.Data.SqlClient;
 
@@ -29,10 +30,10 @@ namespace NServiceBus.Transports.SQLServer
         public void CreateQueueIfNecessary(Address address, string account)
         {
             var connectionParams = connectionStringProvider.GetForDestination(address);
-            using (var connection = new SqlConnection(connectionParams.ConnectionString))
+            using (var connection = sqlConnectionFactory(connectionParams.ConnectionString))
             {
+            	connection.Open();
                 var sql = string.Format(Ddl, connectionParams.Schema, address.GetTableName());
-                connection.Open();
 
                 using (var command = new SqlCommand(sql, connection) {CommandType = CommandType.Text})
                 {
@@ -42,10 +43,12 @@ namespace NServiceBus.Transports.SQLServer
         }
 
         readonly IConnectionStringProvider connectionStringProvider;
+        readonly Func<string, SqlConnection> sqlConnectionFactory;
 
-        public SqlServerQueueCreator(IConnectionStringProvider connectionStringProvider)
+        public SqlServerQueueCreator(IConnectionStringProvider connectionStringProvider, Func<string, SqlConnection> sqlConnectionFactory)
         {
             this.connectionStringProvider = connectionStringProvider;
+            this.sqlConnectionFactory = sqlConnectionFactory;
         }
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -30,9 +30,8 @@ namespace NServiceBus.Transports.SQLServer
         public void CreateQueueIfNecessary(Address address, string account)
         {
             var connectionParams = connectionStringProvider.GetForDestination(address);
-            using (var connection = sqlConnectionFactory(connectionParams.ConnectionString))
+            using (var connection = sqlConnectionFactory.OpenNewConnection(connectionParams.ConnectionString))
             {
-            	connection.Open();
                 var sql = string.Format(Ddl, connectionParams.Schema, address.GetTableName());
 
                 using (var command = new SqlCommand(sql, connection) {CommandType = CommandType.Text})
@@ -43,9 +42,9 @@ namespace NServiceBus.Transports.SQLServer
         }
 
         readonly IConnectionStringProvider connectionStringProvider;
-        readonly Func<string, SqlConnection> sqlConnectionFactory;
+        readonly CustomSqlConnectionFactory sqlConnectionFactory;
 
-        public SqlServerQueueCreator(IConnectionStringProvider connectionStringProvider, Func<string, SqlConnection> sqlConnectionFactory)
+        public SqlServerQueueCreator(IConnectionStringProvider connectionStringProvider, CustomSqlConnectionFactory sqlConnectionFactory)
         {
             this.connectionStringProvider = connectionStringProvider;
             this.sqlConnectionFactory = sqlConnectionFactory;

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transports.SQLServer
 {
-    using System;
     using System.Data;
     using System.Data.SqlClient;
 

--- a/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
@@ -151,7 +151,7 @@
         /// <returns></returns>
         public static TransportExtensions<SqlServerTransport> UseCustomSqlConnectionFactory(this TransportExtensions<SqlServerTransport> transportExtensions, Func<string, SqlConnection> sqlConnectionFactory)
         {
-            transportExtensions.GetSettings().Set(SqlConnectionFactoryConfig.CustomSqlConnectionFactorySettingKey, sqlConnectionFactory);
+            transportExtensions.GetSettings().Set(SqlConnectionFactoryConfig.CustomSqlConnectionFactorySettingKey, new CustomSqlConnectionFactory(sqlConnectionFactory));
             return transportExtensions;
         }
     }

--- a/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.SqlClient;
     using System.Linq;
     using Configuration.AdvanceExtensibility;
     using NServiceBus.Transports.SQLServer;
@@ -139,6 +140,18 @@
         public static TransportExtensions<SqlServerTransport> PauseAfterReceiveFailure(this TransportExtensions<SqlServerTransport> transportExtensions, TimeSpan pauseTime)
         {
             transportExtensions.GetSettings().Set(CircuitBreakerConfig.CircuitBreakerDelayAfterFailureSettingsKey, pauseTime);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Overrides the default time SQL Connections factory.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="sqlConnectionFactory">Factory for creating and opening new SQL Connections.</param>
+        /// <returns></returns>
+        public static TransportExtensions<SqlServerTransport> UseCustomSqlConnectionFactory(this TransportExtensions<SqlServerTransport> transportExtensions, Func<string, SqlConnection> sqlConnectionFactory)
+        {
+            transportExtensions.GetSettings().Set(SqlConnectionFactoryConfig.CustomSqlConnectionFactorySettingKey, sqlConnectionFactory);
             return transportExtensions;
         }
     }


### PR DESCRIPTION
*Make usage of NHibernate compatible with `SET NOCOUNT ON` DB-wide setting #112* issue shows how NOCOUNT server setting can break the NHibernate persistence. It was solved by injecting NHibernate's DriverConnectionProvider, that fixes connections immediately after their opening. However, when SQL Server transport is used, and the same database is used for Timeouts persistence and SQL Transport, it can happen that connections opened for transport can be used by Timeouts persistence routines.

Solution: allow injection of custom SQL connections' factories, like NHibernate does. Such factories can, for example, send `SET NOCOUNT OFF` command immediately after opening the connection.