### PR TITLE
Configure transaction scope options on SQL Server transport level

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -262,6 +262,8 @@
     <Compile Include="MultiSchema\When_custom_schema_configured.cs" />
     <Compile Include="MultiSchema\When_custom_schema_configured_with_transport_discriminator.cs" />
     <Compile Include="MultiSchema\When_custom_schema_configured_with_queue_specific_override.cs" />
+    <Compile Include="TransactionScope\When_customizing_scope_isolation_level.cs" />
+    <Compile Include="TransactionScope\When_using_scope_timeout_greater_than_machine_max.cs" />
     <Compile Include="When_a_corrupted_message_is_received.cs" />
     <Compile Include="When_using_custom_connection_factory.cs" />
   </ItemGroup>

--- a/src/NServiceBus.SqlServer.AcceptanceTests/TransactionScope/When_using_scope_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/TransactionScope/When_using_scope_timeout_greater_than_machine_max.cs
@@ -1,0 +1,42 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests.TransactionScope
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Transports.SQLServer;
+    using NUnit.Framework;
+
+    public class When_using_scope_timeout_greater_than_machine_max : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var exception = Assert.Throws<AggregateException>(async () =>
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>()
+                    .Run();
+            });
+
+            Assert.That(exception.InnerException.InnerException.Message.Contains("Timeout requested is longer than the maximum value for this machine"));
+        }
+
+        private class Context : ScenarioContext
+        {
+        }
+
+        private class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(busConfiguration =>
+                {
+                    busConfiguration.UseTransport<SqlServerTransport>()
+                        .Transactions(TransportTransactionMode.TransactionScope)
+                        .TransactionScopeOptions(timeout: TimeSpan.FromHours(1));
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Data.SqlClient;
     using System.Threading.Tasks;
+    using System.Transactions;
     using NServiceBus.Configuration.AdvanceExtensibility;
 
     //TODO: let's move classes into subfolders?
@@ -67,6 +68,18 @@
 
             transportExtensions.GetSettings().Set(SettingsKeys.ConnectionFactoryOverride, sqlConnectionFactory);
 
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Allows the IsolationLevel and transaction timeout to be changed for the TransactionScope used to receive messages.
+        /// </summary>
+        /// <remarks>
+        /// If not specified the default transaction timeout of the machine will be used and the isolation level will be set to `ReadCommited`.
+        /// </remarks>
+        public static TransportExtensions<SqlServerTransport> TransactionScopeOptions(this TransportExtensions<SqlServerTransport> transportExtensions, TimeSpan? timeout = null, IsolationLevel? isolationLevel = null)
+        {
+            transportExtensions.GetSettings().Set<SqlServerTransport.SqlScopeOptions>(new SqlServerTransport.SqlScopeOptions(timeout, isolationLevel));
             return transportExtensions;
         }
     }


### PR DESCRIPTION
This change allows to set transaction scope options (isolation level and timeout) on transport level for SQL Server transport.

PR with analogous change for the MSMQ transport: particular/NServiceBus#3249.
Doco PR (WIP): particular/docs.particular.net#1026.