### PR TITLE
Correctly remove expired messages from queue

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -275,6 +275,7 @@
     <Compile Include="MultiSchema\When_custom_schema_configured.cs" />
     <Compile Include="MultiSchema\When_custom_schema_configured_with_transport_discriminator.cs" />
     <Compile Include="MultiSchema\When_custom_schema_configured_with_queue_specific_override.cs" />
+    <Compile Include="TimeToBeReceived\When_queue_contains_expired_messages.cs" />
     <Compile Include="TransactionScope\When_customizing_scope_isolation_level.cs" />
     <Compile Include="TransactionScope\When_using_scope_timeout_greater_than_machine_max.cs" />
     <Compile Include="When_a_corrupted_message_is_received.cs" />

--- a/src/NServiceBus.SqlServer.AcceptanceTests/TimeToBeReceived/When_queue_contains_expired_messages.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/TimeToBeReceived/When_queue_contains_expired_messages.cs
@@ -1,0 +1,86 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests.TimeToBeReceived
+{
+    using System.Data.SqlClient;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_queue_contains_expired_messages : NServiceBusAcceptanceTest
+    {
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.None)]
+        public async Task Should_remove_expired_messages_from_queue(TransportTransactionMode transactionMode)
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b =>
+                {
+                    b.CustomConfig(c =>
+                    {
+                        c.UseTransport<SqlServerTransport>()
+                            .Transactions(transactionMode);
+                    });
+                    b.When((bus, c) =>
+                    {
+                        bus.SendLocal(new ExpiredMessage());
+                        bus.SendLocal(new Message());
+                        return Task.FromResult(0);
+                    });
+                })
+                .Done(c => c.MessageWasHandled && QueueIsEmpty())
+                .Run();
+        }
+
+        bool QueueIsEmpty()
+        {
+            var endpoint = Conventions.EndpointNamingConvention(typeof(Endpoint));
+            // TODO: Move opening SQL connection out of the method.
+            using (var connection = new SqlConnection(@"Server=localhost\sqlexpress;Database=nservicebus;Trusted_Connection=True;"))
+            {
+                connection.Open();
+                using (var command = new SqlCommand($"SELECT COUNT(*) FROM [dbo].[{endpoint}]", connection))
+                {
+                    var numberOfMessagesInQueue = (int) command.ExecuteScalar();
+                    return numberOfMessagesInQueue == 0;
+                }
+            }
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageWasHandled { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(1));
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    Context.MessageWasHandled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        [TimeToBeReceived("00:00:00.001")]
+        class ExpiredMessage : IMessage
+        {
+        }
+
+        class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithReceiveOnlyTransaction.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithReceiveOnlyTransaction.cs
@@ -36,34 +36,38 @@
                             return;
                         }
 
-                        if (readResult.Successful)
+                        if (!readResult.Successful)
                         {
-                            var message = readResult.Message;
-
-                            using (var bodyStream = message.BodyStream)
-                            {
-                                var transportTransaction = new TransportTransaction();
-
-                                //those resources are meant to be used by anyone except message dispatcher e.g. persister
-                                transportTransaction.Set(sqlConnection);
-                                transportTransaction.Set(transaction);
-
-                                //this indicates to MessageDispatcher that it should not reuse connection or transaction for sends
-                                transportTransaction.Set(ReceiveOnlyTransactionMode, true);
-
-                                var pushContext = new PushContext(message.TransportId, message.Headers, bodyStream, transportTransaction, cancellationTokenSource, new ContextBag());
-
-                                await onMessage(pushContext).ConfigureAwait(false);
-
-                                if (cancellationTokenSource.Token.IsCancellationRequested)
-                                {
-                                    transaction.Rollback();
-                                    return;
-                                }
-                            }
-
                             transaction.Commit();
+
+                            return;
                         }
+
+                        var message = readResult.Message;
+
+                        using (var bodyStream = message.BodyStream)
+                        {
+                            var transportTransaction = new TransportTransaction();
+
+                            //those resources are meant to be used by anyone except message dispatcher e.g. persister
+                            transportTransaction.Set(sqlConnection);
+                            transportTransaction.Set(transaction);
+
+                            //this indicates to MessageDispatcher that it should not reuse connection or transaction for sends
+                            transportTransaction.Set(ReceiveOnlyTransactionMode, true);
+
+                            var pushContext = new PushContext(message.TransportId, message.Headers, bodyStream, transportTransaction, cancellationTokenSource, new ContextBag());
+
+                            await onMessage(pushContext).ConfigureAwait(false);
+
+                            if (cancellationTokenSource.Token.IsCancellationRequested)
+                            {
+                                transaction.Rollback();
+                                return;
+                            }
+                        }
+
+                        transaction.Commit();
                     }
                     catch (Exception)
                     {
@@ -74,7 +78,6 @@
             }
         }
 
-       
         System.Data.IsolationLevel isolationLevel;
         SqlConnectionFactory connectionFactory;
     }

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
@@ -30,28 +30,32 @@
                     return;
                 }
 
-                if (readResult.Successful)
+                if (!readResult.Successful)
                 {
-                    var message = readResult.Message;
+                    scope.Complete();
 
-                    using (var bodyStream = message.BodyStream)
-                    {
-                        var transportTransaction = new TransportTransaction();
-                        transportTransaction.Set(sqlConnection);
-                        transportTransaction.Set(Transaction.Current);
+                    return;
+                }
 
-                        var pushContext = new PushContext(message.TransportId, message.Headers, bodyStream, transportTransaction, cancellationTokenSource, new ContextBag());
+                var message = readResult.Message;
 
-                        await onMessage(pushContext).ConfigureAwait(false);
-                    }
+                using (var bodyStream = message.BodyStream)
+                {
+                    var transportTransaction = new TransportTransaction();
+                    transportTransaction.Set(sqlConnection);
+                    transportTransaction.Set(Transaction.Current);
+
+                    var pushContext = new PushContext(message.TransportId, message.Headers, bodyStream, transportTransaction, cancellationTokenSource, new ContextBag());
+
+                    await onMessage(pushContext).ConfigureAwait(false);
+                }
 
                 if (cancellationTokenSource.Token.IsCancellationRequested)
                 {
                     return;
                 }
 
-                    scope.Complete();
-                }
+                scope.Complete();
             }
         }
 


### PR DESCRIPTION
SQL Server transport does not currently commit the transaction when it retrieves an expired message from the queue. This results in expired messages being processed indefinitely. This is clearly a regression from V2.

This PR addresses the problem in the same way as V2 (by committing the transaction).