### PR TITLE
V3: SQL Server transport now periodically purges expired messages

### DIFF
--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Transports.SQLServer
 
         public const string LegacyMultiInstanceConnectionFactory = "SqlServer.LegacyMultiInstanceConnectionFactory";
 
-        public const string PurgeTaskDelayKey = "SqlServer.PurgeTaskDelay";
+        public const string PurgeTaskDelayTimeSpanKey = "SqlServer.PurgeTaskDelayTimeSpan";
         public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
     }
 }

--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -9,5 +9,8 @@ namespace NServiceBus.Transports.SQLServer
         public const string TimeToWaitBeforeTriggering = "SqlServer.CircuitBreaker.TimeToWaitBeforeTriggering";
 
         public const string LegacyMultiInstanceConnectionFactory = "SqlServer.LegacyMultiInstanceConnectionFactory";
+
+        public const string PurgeTaskDelayKey = "SqlServer.PurgeTaskDelay";
+        public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
     }
 }

--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
@@ -31,6 +31,8 @@
             var queuePurger = new LegacyQueuePurger(connectionFactory);
             var queuePeeker = new LegacyQueuePeeker(connectionFactory);
 
+            var expiredMessagesPurger = new ExpiredMessagesPurger(settings, queue => connectionFactory.OpenNewConnection(queue.TransportAddress));
+
             SqlScopeOptions scopeOptions;
             if (!settings.TryGet(out scopeOptions))
             {
@@ -55,7 +57,7 @@
                 };
 
             return new TransportReceiveInfrastructure(
-                () => new MessagePump(receiveStrategyFactory, queuePurger, queuePeeker, addressParser, waitTimeCircuitBreaker),
+                () => new MessagePump(receiveStrategyFactory, queuePurger, expiredMessagesPurger, queuePeeker, addressParser, waitTimeCircuitBreaker),
                 () => new LegacyQueueCreator(connectionFactory, addressParser),
                 () => Task.FromResult(StartupCheckResult.Success));
         }

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Legacy\MultiInstance\LegacySqlServerTransportInfrastructure.cs" />
     <Compile Include="obsoletes.cs" />
     <Compile Include="Queuing\DictionarySerializer.cs" />
+    <Compile Include="Receiving\ExpiredMessagesPurger.cs" />
     <Compile Include="Receiving\IsolationLevelMapper.cs" />
     <Compile Include="Receiving\QueuePeeker.cs" />
     <Compile Include="Receiving\QueuePurger.cs" />

--- a/src/NServiceBus.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Message.cs
@@ -14,7 +14,7 @@
             Headers = headers;
         }
 
-        public bool TTBRExpried(DateTime now)
+        public bool TTBRExpired(DateTime now)
         {
             return TimeToBeReceived.HasValue && TimeToBeReceived.Value < now;
         }

--- a/src/NServiceBus.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Message.cs
@@ -6,18 +6,18 @@
 
     class Message
     {
-        public Message(string transportId, DateTime? timeToBeReceived, Dictionary<string, string> headers, Stream bodyStream)
+        public Message(string transportId, int? millisecondsToExpiry, Dictionary<string, string> headers, Stream bodyStream)
         {
             TransportId = transportId;
-            TimeToBeReceived = timeToBeReceived;
+            if (millisecondsToExpiry.HasValue)
+            {
+                TimeToBeReceived = TimeSpan.FromMilliseconds(millisecondsToExpiry.Value);
+            }
             BodyStream = bodyStream;
             Headers = headers;
         }
 
-        public bool TTBRExpired(DateTime now)
-        {
-            return TimeToBeReceived.HasValue && TimeToBeReceived.Value < now;
-        }
+        public bool TTBRExpired => TimeToBeReceived.HasValue && TimeToBeReceived.Value.TotalMilliseconds < 0L;
 
         public string GetLogicalId()
         {
@@ -28,7 +28,7 @@
         }
 
         public string TransportId { get; }
-        public DateTime? TimeToBeReceived { get; }
+        public TimeSpan? TimeToBeReceived { get; }
         public Stream BodyStream { get; }
         public Dictionary<string, string> Headers { get; }
     }

--- a/src/NServiceBus.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Message.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Transports.SQLServer
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
 
@@ -9,15 +8,10 @@
         public Message(string transportId, int? millisecondsToExpiry, Dictionary<string, string> headers, Stream bodyStream)
         {
             TransportId = transportId;
-            if (millisecondsToExpiry.HasValue)
-            {
-                TimeToBeReceived = TimeSpan.FromMilliseconds(millisecondsToExpiry.Value);
-            }
+            TTBRExpired = millisecondsToExpiry.HasValue && millisecondsToExpiry.Value < 0;
             BodyStream = bodyStream;
             Headers = headers;
         }
-
-        public bool TTBRExpired => TimeToBeReceived.HasValue && TimeToBeReceived.Value.TotalMilliseconds < 0L;
 
         public string GetLogicalId()
         {
@@ -28,7 +22,7 @@
         }
 
         public string TransportId { get; }
-        public TimeSpan? TimeToBeReceived { get; }
+        public bool TTBRExpired { get; }
         public Stream BodyStream { get; }
         public Dictionary<string, string> Headers { get; }
     }

--- a/src/NServiceBus.SqlServer/Queuing/MessageParser.cs
+++ b/src/NServiceBus.SqlServer/Queuing/MessageParser.cs
@@ -11,10 +11,10 @@
         {
             var transportId = rowData[0].ToString();
 
-            DateTime? expireDateTime = null;
+            int? millisecondsToExpiry = null;
             if (rowData[Sql.Columns.TimeToBeReceived.Index] != DBNull.Value)
             {
-                expireDateTime = (DateTime) rowData[Sql.Columns.TimeToBeReceived.Index];
+                millisecondsToExpiry = (int) rowData[Sql.Columns.TimeToBeReceived.Index];
             }
 
             var headers = GetHeaders(rowData);
@@ -23,7 +23,7 @@
 
             var memoryStream = new MemoryStream(body);
 
-            var message = new Message(transportId, expireDateTime, headers, memoryStream);
+            var message = new Message(transportId, millisecondsToExpiry, headers, memoryStream);
 
             var replyToAddress = GetNullableValue<string>(rowData[Sql.Columns.ReplyToAddress.Index]);
 
@@ -79,7 +79,7 @@
                 TimeSpan TTBR;
                 if (TimeSpan.TryParse(message.Headers[Headers.TimeToBeReceived], out TTBR) && TTBR != TimeSpan.MaxValue)
                 {
-                    data[Sql.Columns.TimeToBeReceived.Index] = DateTime.UtcNow.Add(TTBR);
+                    data[Sql.Columns.TimeToBeReceived.Index] = TTBR.TotalMilliseconds;
                 }
             }
 

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -44,6 +44,8 @@ namespace NServiceBus.Transports.SQLServer
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
+        internal const string PurgeBatchOfExpiredMessagesText = @"DELETE TOP({0}) FROM[{1}].[{2}] WHERE [Expires] < @Expires";
+
         internal class Columns
         {
             internal static ColumnInfo Id = new ColumnInfo

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Transports.SQLServer
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
-        internal const string PurgeBatchOfExpiredMessagesText = @"DELETE TOP({0}) FROM[{1}].[{2}] WHERE [Expires] < @Expires";
+        internal const string PurgeBatchOfExpiredMessagesText = @"DELETE TOP({0}) FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < @Expires";
 
         internal class Columns
         {

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -39,6 +39,11 @@ namespace NServiceBus.Transports.SQLServer
                         (
 	                        [RowVersion] ASC
                         )WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
+
+                        CREATE NONCLUSTERED INDEX [Index_Expires] ON [{0}].[{1}]
+                        (
+	                        [Expires] ASC
+                        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
                     END
     
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -8,13 +8,13 @@ namespace NServiceBus.Transports.SQLServer
 
         internal const string SendText =
             @"INSERT INTO [{0}].[{1}] ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body]) 
-                                    VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,@Expires,@Headers,@Body)";
+                                    VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,IIF(@TimeToBeReceivedMs IS NOT NULL, DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()), NULL),@Headers,@Body)";
 
         internal const string ReceiveText =
             @"WITH message AS (SELECT TOP(1) * FROM [{0}].[{1}] WITH (UPDLOCK, READPAST, ROWLOCK) ORDER BY [RowVersion]) 
 			DELETE FROM message 
 			OUTPUT deleted.Id, deleted.CorrelationId, deleted.ReplyToAddress, 
-			deleted.Recoverable, deleted.Expires, deleted.Headers, deleted.Body;";
+			deleted.Recoverable, IIF(deleted.Expires IS NOT NULL, DATEDIFF(ms, GETUTCDATE(), deleted.Expires), NULL), deleted.Headers, deleted.Body;";
         
         internal const string PeekText = @"SELECT count(*) Id FROM [{0}].[{1}];";
 
@@ -43,13 +43,23 @@ namespace NServiceBus.Transports.SQLServer
                         CREATE NONCLUSTERED INDEX [Index_Expires] ON [{0}].[{1}]
                         (
 	                        [Expires] ASC
-                        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+                        )
+                        INCLUDE
+                        (
+                            [Id],
+                            [RowVersion]
+                        )
+                        WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
                     END
     
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
-        internal const string PurgeBatchOfExpiredMessagesText = @"DELETE TOP({0}) FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < @Expires";
+        internal const string PurgeBatchOfExpiredMessagesText = @"DELETE FROM [{1}].[{2}] WHERE [Id] IN (SELECT TOP ({0}) [Id] FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE() ORDER BY [RowVersion])";
+
+        internal const string CheckIfExpiresIndexIsPresent = @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('[{1}].[{2}]')";
+
+        internal const string ExpiresIndexName = "Index_Expires";
 
         internal class Columns
         {
@@ -84,8 +94,8 @@ namespace NServiceBus.Transports.SQLServer
             internal static ColumnInfo TimeToBeReceived = new ColumnInfo
             {
                 Index = 4,
-                Name = "Expires",
-                Type = SqlDbType.DateTime
+                Name = "TimeToBeReceivedMs",
+                Type = SqlDbType.Int
             };
 
             internal static ColumnInfo Headers = new ColumnInfo

--- a/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
@@ -153,8 +153,7 @@ namespace NServiceBus.Transports.SQLServer
 
                 if (rowsCount == 0)
                 {
-                    Logger.WarnFormat(@"Table [{0}].[{1}] does not contain index '{2}'.
-Adding this index will speed up the process of purging expired messages from the queue. Please consult the documentation for further information.", this.address.SchemaName, this.address.TableName, Sql.ExpiresIndexName);
+                    Logger.WarnFormat(@"Table [{0}].[{1}] does not contain index '{2}'." + Environment.NewLine + "Adding this index will speed up the process of purging expired messages from the queue. Please consult the documentation for further information.", this.address.SchemaName, this.address.TableName, Sql.ExpiresIndexName);
                 }
             }
         }

--- a/src/NServiceBus.SqlServer/Receiving/ExpiredMessagesPurger.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ExpiredMessagesPurger.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus.Logging;
+    using NServiceBus.Settings;
+
+    interface IPurgeExpiredMessages
+    {
+        Task Purge(TableBasedQueue queue, CancellationToken cancellationToken);
+    }
+
+    class ExpiredMessagesPurger : IPurgeExpiredMessages
+    {
+        public ExpiredMessagesPurger(SettingsHolder settings, Func<TableBasedQueue, Task<SqlConnection>> openConnection)
+        {
+            this.openConnection = openConnection;
+
+            if (!settings.TryGet(SettingsKeys.PurgeTaskDelayKey, out purgeTaskDelay))
+            {
+                purgeTaskDelay = DefaultPurgeTaskDelay;
+            }
+
+            if (!settings.TryGet(SettingsKeys.PurgeBatchSizeKey, out purgeBatchSize))
+            {
+                purgeBatchSize = DefaultPurgeBatchSize;
+            }
+        }
+
+        public async Task Purge(TableBasedQueue queue, CancellationToken cancellationToken)
+        {
+            await LogWarningWhenIndexIsMissing(queue).ConfigureAwait(false);
+
+            Logger.DebugFormat("Starting a new expired message purge task for table {0}.", queue);
+
+            var totalPurgedRowsCount = 0;
+
+            try
+            {
+                using (var connection = await openConnection(queue).ConfigureAwait(false))
+                {
+                    var continuePurging = true;
+
+                    while (continuePurging && !cancellationToken.IsCancellationRequested)
+                    {
+                        var purgedRowsCount = await queue.PurgeBatchOfExpiredMessages(connection, purgeBatchSize).ConfigureAwait(false);
+
+                        totalPurgedRowsCount += purgedRowsCount;
+                        continuePurging = (purgedRowsCount == purgeBatchSize);
+                    }
+                }
+
+                if (totalPurgedRowsCount > 0)
+                {
+                    Logger.InfoFormat("{0} expired messages were successfully purged from table {1}", totalPurgedRowsCount, queue);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WarnFormat("Purging expired messages from table {0} failed after purging {1} messages. Exception: {2}", queue, totalPurgedRowsCount, ex);
+            }
+
+            Logger.DebugFormat("Scheduling next expired message purge task for table {0} in {1}", queue, purgeTaskDelay);
+            await Task.Delay(purgeTaskDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        async Task LogWarningWhenIndexIsMissing(TableBasedQueue queue)
+        {
+            try
+            {
+                using (var connection = await openConnection(queue).ConfigureAwait(false))
+                {
+                    await queue.LogWarningWhenIndexIsMissing(connection).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WarnFormat("Checking indexes on table {0} failed. Exception: {1}", queue, ex);
+            }
+        }
+
+        Func<TableBasedQueue, Task<SqlConnection>> openConnection;
+
+        TimeSpan purgeTaskDelay;
+        int purgeBatchSize;
+
+        static readonly TimeSpan DefaultPurgeTaskDelay = TimeSpan.FromMinutes(5);
+        const int DefaultPurgeBatchSize = 10000;
+
+        static ILog Logger = LogManager.GetLogger<ExpiredMessagesPurger>();
+    }
+}

--- a/src/NServiceBus.SqlServer/Receiving/ExpiredMessagesPurger.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ExpiredMessagesPurger.cs
@@ -5,34 +5,19 @@
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Logging;
-    using NServiceBus.Settings;
 
-    interface IPurgeExpiredMessages
+    class ExpiredMessagesPurger
     {
-        Task Purge(TableBasedQueue queue, CancellationToken cancellationToken);
-    }
-
-    class ExpiredMessagesPurger : IPurgeExpiredMessages
-    {
-        public ExpiredMessagesPurger(SettingsHolder settings, Func<TableBasedQueue, Task<SqlConnection>> openConnection)
+        public ExpiredMessagesPurger(Func<TableBasedQueue, Task<SqlConnection>> openConnection, TimeSpan? purgeTaskDelay, int? purgeBatchSize)
         {
             this.openConnection = openConnection;
 
-            if (!settings.TryGet(SettingsKeys.PurgeTaskDelayKey, out purgeTaskDelay))
-            {
-                purgeTaskDelay = DefaultPurgeTaskDelay;
-            }
-
-            if (!settings.TryGet(SettingsKeys.PurgeBatchSizeKey, out purgeBatchSize))
-            {
-                purgeBatchSize = DefaultPurgeBatchSize;
-            }
+            PurgeTaskDelay = purgeTaskDelay ?? DefaultPurgeTaskDelay;
+            PurgeBatchSize = purgeBatchSize ?? DefaultPurgeBatchSize;
         }
 
         public async Task Purge(TableBasedQueue queue, CancellationToken cancellationToken)
         {
-            await LogWarningWhenIndexIsMissing(queue).ConfigureAwait(false);
-
             Logger.DebugFormat("Starting a new expired message purge task for table {0}.", queue);
 
             var totalPurgedRowsCount = 0;
@@ -45,28 +30,22 @@
 
                     while (continuePurging && !cancellationToken.IsCancellationRequested)
                     {
-                        var purgedRowsCount = await queue.PurgeBatchOfExpiredMessages(connection, purgeBatchSize).ConfigureAwait(false);
+                        var purgedRowsCount = await queue.PurgeBatchOfExpiredMessages(connection, PurgeBatchSize).ConfigureAwait(false);
 
                         totalPurgedRowsCount += purgedRowsCount;
-                        continuePurging = (purgedRowsCount == purgeBatchSize);
+                        continuePurging = (purgedRowsCount == PurgeBatchSize);
                     }
                 }
 
-                if (totalPurgedRowsCount > 0)
-                {
-                    Logger.InfoFormat("{0} expired messages were successfully purged from table {1}", totalPurgedRowsCount, queue);
-                }
+                Logger.DebugFormat("{0} expired messages were successfully purged from table {1}", totalPurgedRowsCount, queue);
             }
             catch (Exception ex)
             {
                 Logger.WarnFormat("Purging expired messages from table {0} failed after purging {1} messages. Exception: {2}", queue, totalPurgedRowsCount, ex);
             }
-
-            Logger.DebugFormat("Scheduling next expired message purge task for table {0} in {1}", queue, purgeTaskDelay);
-            await Task.Delay(purgeTaskDelay, cancellationToken).ConfigureAwait(false);
         }
 
-        async Task LogWarningWhenIndexIsMissing(TableBasedQueue queue)
+        public async Task Initialize(TableBasedQueue queue)
         {
             try
             {
@@ -83,8 +62,9 @@
 
         Func<TableBasedQueue, Task<SqlConnection>> openConnection;
 
-        TimeSpan purgeTaskDelay;
-        int purgeBatchSize;
+        public TimeSpan PurgeTaskDelay { get; }
+
+        int PurgeBatchSize { get; }
 
         static readonly TimeSpan DefaultPurgeTaskDelay = TimeSpan.FromMinutes(5);
         const int DefaultPurgeBatchSize = 10000;

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -73,8 +73,10 @@ namespace NServiceBus
             var queuePurger = new QueuePurger(connectionFactory);
             var queuePeeker = new QueuePeeker(connectionFactory);
 
+            var expiredMessagesPurger = new ExpiredMessagesPurger(settings, _ => connectionFactory.OpenNewConnection());
+
             return new TransportReceiveInfrastructure(
-                () => new MessagePump(receiveStrategyFactory, queuePurger, queuePeeker, addressParser, waitTimeCircuitBreaker),
+                () => new MessagePump(receiveStrategyFactory, queuePurger, expiredMessagesPurger, queuePeeker, addressParser, waitTimeCircuitBreaker),
                 () => new QueueCreator(connectionFactory, addressParser),
                 () => Task.FromResult(StartupCheckResult.Success));
         }


### PR DESCRIPTION
Taskforce: @MarcinHoppe @tmasternak 

In the actual versions (V2 & V3) of the transport [TTBR messages](http://docs.particular.net/nservicebus/messaging/discard-old-messages) are handled by endpoint process, this means thjat if the input queue is load with a lot of expired messages the endpoint will waste a lot of time at startup dealing with expired messages before being able to start consuming non expired ones.

We should handle such a scenario better. /cc @tmasternak @ramonsmits 
Inception: https://github.com/Particular/CustomerSuccess/issues/166

### TODO:
- [x] Add index on the `Expires` column
- [x] Run performance tests
- [x] Doco PR
- [x] Backport to V2
- [x] Upgrade guide PR: Particular/docs.particular.net#1290