### PR TITLE
V2: SQL Server transport now periodically purges expired messages

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_in_native_transaction_mode.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_in_native_transaction_mode.cs
@@ -19,10 +19,11 @@ namespace NServiceBus.SqlServer.AcceptanceTests
             var context = new Context();
             Scenario.Define(context)
                    .WithEndpoint<Receiver>(b => b.CustomConfig(c => AddConnectionString("NServiceBus/Transport/OtherEndpoint", OtherDatabaseConnectionString)))
+                   .AllowExceptions()
                    .Done(c => true)
                    .Run();
 
-            Assert.IsTrue(context.Exceptions.Contains(ExceptionText));
+            StringAssert.Contains(ExceptionText, context.Exceptions);
         }
         
         [Test]
@@ -33,10 +34,11 @@ namespace NServiceBus.SqlServer.AcceptanceTests
                    .WithEndpoint<Receiver>(b => b.CustomConfig(c => c.UseTransport<SqlServerTransport>().UseSpecificConnectionInformation(
                        EndpointConnectionInfo.For("A").UseConnectionString(OtherDatabaseConnectionString)
                        )))
+                   .AllowExceptions()
                    .Done(c => true)
                    .Run();
 
-            Assert.IsTrue(context.Exceptions.Contains(ExceptionText));
+            StringAssert.Contains(ExceptionText, context.Exceptions);
         } 
         
         [Test]
@@ -47,10 +49,11 @@ namespace NServiceBus.SqlServer.AcceptanceTests
                    .WithEndpoint<Receiver>(b => b.CustomConfig(c => c.UseTransport<SqlServerTransport>().UseSpecificConnectionInformation(
                        e => ConnectionInfo.Create().UseSchema("nsb")
                        )))
+                   .AllowExceptions()
                    .Done(c => true)
                    .Run();
 
-            Assert.IsTrue(context.Exceptions.Contains(ExceptionText));
+            StringAssert.Contains(ExceptionText, context.Exceptions);
         }
 
         [Test]

--- a/src/NServiceBus.SqlServer.UnitTests/AdaptiveExecutorSimulator/RealSimulator.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/AdaptiveExecutorSimulator/RealSimulator.cs
@@ -42,7 +42,8 @@
                 new QueuePurger(new SecondaryReceiveConfiguration(_ => SecondaryReceiveSettings.Disabled()), localConnectionParams, ConnectionFactory.Default()), 
                 new SecondaryReceiveConfiguration(_ => SecondaryReceiveSettings.Disabled()),
                 transportNotifications,
-                new RepeatedFailuresOverTimeCircuitBreaker("A", TimeSpan.FromDays(1000), _ => { }));
+                new RepeatedFailuresOverTimeCircuitBreaker("A", TimeSpan.FromDays(1000), _ => { }),
+                ConnectionFactory.Default());
 
             dequeueStrategy.Init(Address.Parse(address), new TransactionSettings(true, TimeSpan.FromMinutes(2), System.Transactions.IsolationLevel.ReadCommitted, 1, false, false),
                 ProcessMessage, (message, exception) => { });

--- a/src/NServiceBus.SqlServer.UnitTests/AdaptiveExecutorSimulator/RealSimulator.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/AdaptiveExecutorSimulator/RealSimulator.cs
@@ -37,13 +37,20 @@
             taskStarted = transportNotifications.ReceiveTaskStarted.Subscribe(x => AddMessage("Thread started"));
             taskEnded = transportNotifications.ReceiveTaskStopped.Subscribe(x => AddMessage("Thread died"));
 
+            var purgeExpiredMessagesParams = new PurgeExpiredMessagesParams
+            {
+                PurgeTaskDelay = Timeout.InfiniteTimeSpan,
+                PurgeBatchSize = 1
+            };
+
             dequeueStrategy = new SqlServerPollingDequeueStrategy(localConnectionParams,
                 new ReceiveStrategyFactory(new DummyConnectionStore(), localConnectionParams, Address.Parse("error"), ConnectionFactory.Default()),
                 new QueuePurger(new SecondaryReceiveConfiguration(_ => SecondaryReceiveSettings.Disabled()), localConnectionParams, ConnectionFactory.Default()), 
                 new SecondaryReceiveConfiguration(_ => SecondaryReceiveSettings.Disabled()),
                 transportNotifications,
                 new RepeatedFailuresOverTimeCircuitBreaker("A", TimeSpan.FromDays(1000), _ => { }),
-                ConnectionFactory.Default());
+                ConnectionFactory.Default(),
+                purgeExpiredMessagesParams);
 
             dequeueStrategy.Init(Address.Parse(address), new TransactionSettings(true, TimeSpan.FromMinutes(2), System.Transactions.IsolationLevel.ReadCommitted, 1, false, false),
                 ProcessMessage, (message, exception) => { });

--- a/src/NServiceBus.SqlServer/ExpiredMessagesPurger.cs
+++ b/src/NServiceBus.SqlServer/ExpiredMessagesPurger.cs
@@ -1,0 +1,120 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Threading;
+    using NServiceBus.Logging;
+
+    class ExpiredMessagesPurger : IExecutor
+    {
+        static readonly TimeSpan purgeTaskDelay = TimeSpan.FromMinutes(5);
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(ExpiredMessagesPurger));
+
+        readonly TableBasedQueue queue;
+        readonly Func<SqlConnection> openConnection;
+
+        Timer purgeTaskTimer;
+        CancellationToken token;
+
+        object lockObject = new object();
+
+        public ExpiredMessagesPurger(TableBasedQueue queue, Func<SqlConnection> openConnection)
+        {
+            this.queue = queue;
+            this.openConnection = openConnection;
+        }
+
+        public void Start(int maximumConcurrency, CancellationToken token)
+        {
+            LogWarningWhenIndexIsMissing();
+
+            this.token = token;
+            purgeTaskTimer = new Timer(PurgeExpiredMessagesCallback, null, TimeSpan.Zero, purgeTaskDelay);
+        }
+
+        public void Stop()
+        {
+            using (var waitHandle = new ManualResetEvent(false))
+            {
+                purgeTaskTimer.Dispose(waitHandle);
+                waitHandle.WaitOne();
+            }
+        }
+
+        void LogWarningWhenIndexIsMissing()
+        {
+            try
+            {
+                using (var connection = openConnection())
+                {
+                    queue.LogWarningWhenIndexIsMissing(connection);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WarnFormat("Checking indexes on table {0} failed. Exception: {1}", queue, ex);
+            }
+        }
+
+        void PurgeExpiredMessagesCallback(object state)
+        {
+            Logger.DebugFormat("Starting a new expired message purge task for table {0}.", queue);
+
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var lockTaken = false;
+            try
+            {
+                Monitor.TryEnter(lockObject, ref lockTaken);
+                if (!lockTaken)
+                {
+                    Logger.DebugFormat("An expired message purge task for table {0} is already running. Nothing to do.", queue);
+                    return;
+                }
+
+                PurgeExpiredMessages();
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    Monitor.Exit(lockObject);
+                }
+            }
+        }
+
+        void PurgeExpiredMessages()
+        {
+            int totalPurgedRowsCount = 0;
+
+            try
+            {
+                using (var connection = openConnection())
+                {
+                    var continuePurging = true;
+
+                    while (continuePurging && !token.IsCancellationRequested)
+                    {
+                        var purgedRowsCount = queue.PurgeBatchOfExpiredMessages(connection);
+
+                        totalPurgedRowsCount += purgedRowsCount;
+                        continuePurging = (purgedRowsCount == TableBasedQueue.PurgeBatchSize);
+                    }
+                }
+
+                if (totalPurgedRowsCount > 0)
+                {
+                    Logger.InfoFormat("{0} expired messages were successfully purged from table {1}", totalPurgedRowsCount, queue);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WarnFormat("Purging expired messages from table {0} failed after purging {1} messages. Exception: {2}", queue, totalPurgedRowsCount, ex);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Observable.cs" />
     <Compile Include="IConnectionStore.cs" />
     <Compile Include="PipelineNotifications.cs" />
+    <Compile Include="PurgeExpiredMessagesParams.cs" />
     <Compile Include="QueuePurger.cs" />
     <Compile Include="ReadIncomingCallbackAddressBehavior.cs" />
     <Compile Include="ReceiveRampUpController.cs" />

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -70,6 +70,7 @@
     <Compile Include="BoundedExponentialBackOff.cs" />
     <Compile Include="CallbackQueueCreator.cs" />
     <Compile Include="ExecutorTaskState.cs" />
+    <Compile Include="ExpiredMessagesPurger.cs" />
     <Compile Include="IBackOffStrategy.cs" />
     <Compile Include="ICallbackAddressStore.cs" />
     <Compile Include="CollectionConnectionStringProvider.cs" />

--- a/src/NServiceBus.SqlServer/PurgeExpiredMessagesParams.cs
+++ b/src/NServiceBus.SqlServer/PurgeExpiredMessagesParams.cs
@@ -1,0 +1,10 @@
+﻿namespace NServiceBus.Transports.SQLServer
+{
+    using System;
+
+    class PurgeExpiredMessagesParams
+    {
+        public TimeSpan PurgeTaskDelay { get; set; }
+        public int PurgeBatchSize { get; set; }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServerPollingDequeueStrategy.cs
+++ b/src/NServiceBus.SqlServer/SqlServerPollingDequeueStrategy.cs
@@ -19,7 +19,8 @@
             SecondaryReceiveConfiguration secondaryReceiveConfiguration,
             TransportNotifications transportNotifications, 
             RepeatedFailuresOverTimeCircuitBreaker circuitBreaker,
-            ConnectionFactory connectionFactory)
+            ConnectionFactory connectionFactory,
+            PurgeExpiredMessagesParams purgeExpiredMessagesParams)
         {
             this.locaConnectionParams = locaConnectionParams;
             this.receiveStrategyFactory = receiveStrategyFactory;
@@ -28,6 +29,7 @@
             this.transportNotifications = transportNotifications;
             this.circuitBreaker = circuitBreaker;
             this.connectionFactory = connectionFactory;
+            this.purgeExpiredMessagesParams = purgeExpiredMessagesParams;
         }
 
         /// <summary>
@@ -63,7 +65,7 @@
                 secondaryReceiver = new NullExecutor();
             }
 
-            expiredMessagesPurger = new ExpiredMessagesPurger(primaryQueue, () => connectionFactory.OpenNewConnection(locaConnectionParams.ConnectionString));
+            expiredMessagesPurger = new ExpiredMessagesPurger(primaryQueue, () => connectionFactory.OpenNewConnection(locaConnectionParams.ConnectionString), purgeExpiredMessagesParams);
         }
 
         /// <summary>
@@ -125,6 +127,7 @@
         readonly ReceiveStrategyFactory receiveStrategyFactory;
         readonly IQueuePurger queuePurger;
         readonly ConnectionFactory connectionFactory;
+        readonly PurgeExpiredMessagesParams purgeExpiredMessagesParams;
 
         readonly SecondaryReceiveConfiguration secondaryReceiveConfiguration;
         [SkipWeaving] //Do not dispose with dequeue strategy

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -27,7 +27,13 @@ namespace NServiceBus.Transports.SQLServer
                     CREATE NONCLUSTERED INDEX [Index_Expires] ON [{0}].[{1}]
                     (
 	                    [Expires] ASC
-                    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+                    )
+                    INCLUDE
+                    (
+                        [Id],
+                        [RowVersion]
+                    )
+                    WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
 
                   END";
 

--- a/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/SqlServerQueueCreator.cs
@@ -24,6 +24,11 @@ namespace NServiceBus.Transports.SQLServer
 	                    [RowVersion] ASC
                     )WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
                     
+                    CREATE NONCLUSTERED INDEX [Index_Expires] ON [{0}].[{1}]
+                    (
+	                    [Expires] ASC
+                    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+
                   END";
 
         public void CreateQueueIfNecessary(Address address, string account)

--- a/src/NServiceBus.SqlServer/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/TableBasedQueue.cs
@@ -189,9 +189,9 @@ namespace NServiceBus.Transports.SQLServer
             return (T)value;
         }
 
-        public int PurgeBatchOfExpiredMessages(SqlConnection connection)
+        public int PurgeBatchOfExpiredMessages(SqlConnection connection, int purgeBatchSize)
         {
-            var commandText = string.Format(SqlPurgeBatchOfExpiredMessages, PurgeBatchSize, this.schema, this.tableName);
+            var commandText = string.Format(SqlPurgeBatchOfExpiredMessages, purgeBatchSize, this.schema, this.tableName);
 
             using (var command = new SqlCommand(commandText, connection))
             {
@@ -256,8 +256,6 @@ Adding this index will speed up the process of purging expired messages from the
 
         const string SqlCheckIfExpiresIndexIsPresent =
             @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('[{1}].[{2}]')";
-
-        public const int PurgeBatchSize = 10000;
 
         const string ExpiresIndexName = "Index_Expires";
 

--- a/src/NServiceBus.SqlServer/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/TableBasedQueue.cs
@@ -78,7 +78,7 @@ namespace NServiceBus.Transports.SQLServer
             }
             else
             {
-                data[TimeToBeReceivedColumn] = DateTime.UtcNow.Add(message.TimeToBeReceived);
+                data[TimeToBeReceivedColumn] = message.TimeToBeReceived.TotalMilliseconds;
             }
             data[HeadersColumn] = HeaderSerializer.SerializeObject(message.Headers);
             if (message.Body == null)
@@ -129,14 +129,14 @@ namespace NServiceBus.Transports.SQLServer
             {
                 var id = rowData[0].ToString();
 
-                DateTime? expireDateTime = null;
+                int? millisecondsToExpiry = null;
                 if (rowData[TimeToBeReceivedColumn] != DBNull.Value)
                 {
-                    expireDateTime = (DateTime)rowData[TimeToBeReceivedColumn];
+                    millisecondsToExpiry = (int)rowData[TimeToBeReceivedColumn];
                 }
 
                 //Has message expired?
-                if (expireDateTime.HasValue && expireDateTime.Value < DateTime.UtcNow)
+                if (millisecondsToExpiry.HasValue && millisecondsToExpiry.Value < 0L)
                 {
                     Logger.InfoFormat("Message with ID={0} has expired. Removing it from queue.", id);
                     return MessageReadResult.NoMessage;
@@ -161,9 +161,9 @@ namespace NServiceBus.Transports.SQLServer
                     message.Headers[Headers.ReplyToAddress] = replyToAddress;
                 }
 
-                if (expireDateTime.HasValue)
+                if (millisecondsToExpiry.HasValue)
                 {
-                    message.TimeToBeReceived = TimeSpan.FromTicks(expireDateTime.Value.Ticks - DateTime.UtcNow.Ticks);
+                    message.TimeToBeReceived = TimeSpan.FromMilliseconds(millisecondsToExpiry.Value);
                 }
 
                 return MessageReadResult.Success(message);
@@ -195,8 +195,6 @@ namespace NServiceBus.Transports.SQLServer
 
             using (var command = new SqlCommand(commandText, connection))
             {
-                command.Parameters.Add("UTCNow", SqlDbType.DateTime).Value = DateTime.UtcNow;
-
                 return command.ExecuteNonQuery();
             }
         }
@@ -228,7 +226,7 @@ Adding this index will speed up the process of purging expired messages from the
         readonly string schema;
         static  readonly JsonMessageSerializer HeaderSerializer = new JsonMessageSerializer(null);
 
-        static readonly string[] Parameters = { "Id", "CorrelationId", "ReplyToAddress", "Recoverable", "Expires", "Headers", "Body" };
+        static readonly string[] Parameters = { "Id", "CorrelationId", "ReplyToAddress", "Recoverable", "TimeToBeReceivedMs", "Headers", "Body" };
 
         static readonly SqlDbType[] ParameterTypes =
         {
@@ -236,23 +234,23 @@ Adding this index will speed up the process of purging expired messages from the
             SqlDbType.VarChar,
             SqlDbType.VarChar,
             SqlDbType.Bit,
-            SqlDbType.DateTime,
+            SqlDbType.Int,
             SqlDbType.VarChar,
             SqlDbType.VarBinary
         };
 
         const string SqlSend =
             @"INSERT INTO [{0}].[{1}] ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body]) 
-                                    VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,@Expires,@Headers,@Body)";
+                                    VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,IIF(@TimeToBeReceivedMs IS NOT NULL, DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()), NULL),@Headers,@Body)";
 
         const string SqlReceive =
             @"WITH message AS (SELECT TOP(1) * FROM [{0}].[{1}] WITH (UPDLOCK, READPAST, ROWLOCK) ORDER BY [RowVersion] ASC) 
 			DELETE FROM message 
 			OUTPUT deleted.Id, deleted.CorrelationId, deleted.ReplyToAddress, 
-			deleted.Recoverable, deleted.Expires, deleted.Headers, deleted.Body;";
+			deleted.Recoverable, IIF(deleted.Expires IS NOT NULL, DATEDIFF(ms, GETUTCDATE(), deleted.Expires), NULL), deleted.Headers, deleted.Body;";
 
         const string SqlPurgeBatchOfExpiredMessages =
-            @"DELETE TOP({0}) FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < @UTCNow";
+            @"DELETE TOP({0}) FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE()";
 
         const string SqlCheckIfExpiresIndexIsPresent =
             @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('[{1}].[{2}]')";

--- a/src/NServiceBus.SqlServer/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/TableBasedQueue.cs
@@ -250,7 +250,7 @@ Adding this index will speed up the process of purging expired messages from the
 			deleted.Recoverable, IIF(deleted.Expires IS NOT NULL, DATEDIFF(ms, GETUTCDATE(), deleted.Expires), NULL), deleted.Headers, deleted.Body;";
 
         const string SqlPurgeBatchOfExpiredMessages =
-            @"DELETE TOP({0}) FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE()";
+            @"DELETE FROM [{1}].[{2}] WHERE [Id] IN (SELECT TOP ({0}) [Id] FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE() ORDER BY [RowVersion])";
 
         const string SqlCheckIfExpiresIndexIsPresent =
             @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('[{1}].[{2}]')";


### PR DESCRIPTION
Taskforce: @MarcinHoppe @tmasternak 

SQL Server transport discards expired messages when it receives them from the queue table. If the endpoint is down for some time and expired messages build up in the queue, the endpoint will need to receive all of these messages in order to discard them.

The solution is to purge expired messages at the startup of the endpoint and then periodically after every 5 minutes. The purging is done in batches, 10000 rows at a time until there are no more expired messages in the queue.

## Who's affected

Users of the SQL Server transport receiving messages with `TimeToBeReceived` attribute.

## Symptoms

When there is a backlog of expired messages in the queue table, then upon the startup of the endpoint the log will contain the following line for each expired message:

`Message with ID=<Message ID> has expired. Removing it from queue.`

## Deployment

Optimal performance of this solution requires that an additional index be created on each of the queue tables. The following SQL statement may be used to create the index:

```SQL
CREATE NONCLUSTERED INDEX [Index_Expires] ON [<SCHEMA>].[<QUEUE_TABLE>]
(
	[Expires] ASC
)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
```
## Workaround

A manual workaround is to manually purge expired messages using the following SQL statement:

```SQL
DELETE FROM [<SCHEMA>].[<QUEUE_TABLE>] WITH (UPDLOCK, READPAST, ROWLOCK)
WHERE [Expires] < GETUTCDATE()
```

The query above may cause a significant growth of the transaction log if there are many rows affected. The recommended technique to mitigate this problem is to split the single query into chunks:

```SQL
DECLARE @rows_deleted INT = 1;

WHILE @rows_deleted > 0
BEGIN
	BEGIN TRANSACTION;

	DELETE TOP(10000) FROM [<SCHEMA>].[<QUEUE_TABLE>] WITH (UPDLOCK, READPAST, ROWLOCK)
	WHERE [Expires] < GETUTCDATE();

	SET @rows_deleted = @@ROWCOUNT;

	COMMIT TRANSACTION;
END
```
### Things to be completed before release

- [x] Doco PR: Particular/docs.particular.net#1224
- [x] Announcement PR: Particular/Announcements#82

### Things to be completed after release
- [ ] Ping the @Particular/servicecontrol-maintainers to schedule a ServiceControl release