### PR TITLE
Add UseConnectionString to obsoletes

### DIFF
--- a/src/NServiceBus.SqlServer/obsoletes.cs
+++ b/src/NServiceBus.SqlServer/obsoletes.cs
@@ -78,6 +78,13 @@ namespace NServiceBus.Transports.SQLServer.ConnectionStrings
         {
             throw new NotImplementedException();
         }
+
+        [ObsoleteEx(RemoveInVersion = "4.0", TreatAsErrorFromVersion = "3.0",
+            Message = "Multi-database setup is currently not supported. To specify schema use `UseSpecificSchema()`.")]
+        public ConnectionInfo UseConnectionString(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class EndpointConnectionInfo


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.SqlServer/issues/148

This adds the `UseConnectionString` method to the obsoletes so intellisense still shows the method but compiling results in an error.