### PR TITLE
Escape schema name in queue address

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_with_bracketed_transport_discriminator.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_with_bracketed_transport_discriminator.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests.MultiSchema
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+    using static AcceptanceTesting.Customization.Conventions;
+
+    public class When_custom_schema_configured_with_bracketed_transport_discriminator : When_custom_schema_configured
+    {
+        [Test]
+        public async void Should_receive_message()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When((bus, c) => bus.Send(new Message())))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.MessageReceived)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.MessageReceived, "Message should be properly received"))
+                .Run();
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var ReceiverName = $"{EndpointNamingConvention(typeof(Receiver))}";
+                    
+                    c.Routing().UnicastRoutingTable.RouteToEndpoint(typeof(Message), $"{ReceiverName}@[{ReceiverSchema}]");
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -279,6 +279,7 @@
     <Compile Include="LegacyMultiInstance\When_using_legacy_multiinstance.cs" />
     <Compile Include="LegacyMultiInstance\When_using_legacy_multiinstance_mode_with_custom_schema.cs" />
     <Compile Include="LegacyMultiInstance\When_using_legacy_multiinstance_with_transaction_mode_different_from_distributed.cs" />
+    <Compile Include="MultiSchema\When_custom_schema_configured_with_bracketed_transport_discriminator.cs" />
     <Compile Include="When_the_message_contains_a_legacy_callback_header.cs" />
     <Compile Include="Configuration\AppConfig.cs" />
     <Compile Include="ConfigureEndpointSqlServerTransport.cs" />

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationValidatorTests.cs" />
+    <Compile Include="QueueAddressTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NServiceBus.snk" />

--- a/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
@@ -23,19 +23,16 @@
 
 
         [Test]
-        [TestCase("table", "schema", "schema")]
-        [TestCase("my.table", "my.schema", "my.schema")]
-        [TestCase("table", "", null)]
-        [TestCase("table", null, null)]
-        [TestCase("table", "[my.schema]", "my.schema")]
-        [TestCase("[my.table]", "[my.schema]", "my.schema")]
-        public void Should_parse_address(string tableName, string schemaName, string expectedSchema)
+        [TestCase("table@schema", "table", "schema")]
+        [TestCase("my.table@my.schema@my.schema", "my.table", "my.schema")]
+        [TestCase("table", "table", null)]
+        [TestCase("table@[my.schema]", "table", "my.schema")]
+        [TestCase("[my.table]@[my.schema]", "[my.table]", "my.schema")]
+        public void Should_parse_address(string transportAddress, string expectedTableName, string expectedSchema)
         {
-            var address = new QueueAddress(tableName, schemaName);
+            var parsedAddress = QueueAddress.Parse(transportAddress);
 
-            var parsedAddress = QueueAddress.Parse(address.ToString());
-
-            Assert.AreEqual(tableName, parsedAddress.TableName);
+            Assert.AreEqual(expectedTableName, parsedAddress.TableName);
             Assert.AreEqual(expectedSchema, parsedAddress.SchemaName);
         }
     }

--- a/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
@@ -1,0 +1,42 @@
+﻿namespace NServiceBus.SqlServer.UnitTests
+{
+    using NServiceBus.Transports.SQLServer;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class QueueAddressTests
+    {
+
+        [Test]
+        [TestCase("table", "schema", "table@[schema]")]
+        [TestCase("my.table", "my.schema", "my.table@[my.schema]")]
+        [TestCase("table", "", "table")]
+        [TestCase("table", null, "table")]
+        [TestCase("table", "[my.schema]", "table@[my.schema]")]
+        [TestCase("[my.table]", "[my.schema]", "[my.table]@[my.schema]")]
+        public void Should_include_brackets_around_schema_name(string tableName, string schemaName, string expectedAddress)
+        {
+            var address = new QueueAddress(tableName, schemaName);
+
+            Assert.AreEqual(expectedAddress, address.ToString());
+        }
+
+
+        [Test]
+        [TestCase("table", "schema", "schema")]
+        [TestCase("my.table", "my.schema", "my.schema")]
+        [TestCase("table", "", null)]
+        [TestCase("table", null, null)]
+        [TestCase("table", "[my.schema]", "my.schema")]
+        [TestCase("[my.table]", "[my.schema]", "my.schema")]
+        public void Should_parse_address(string tableName, string schemaName, string expectedSchema)
+        {
+            var address = new QueueAddress(tableName, schemaName);
+
+            var parsedAddress = QueueAddress.Parse(address.ToString());
+
+            Assert.AreEqual(tableName, parsedAddress.TableName);
+            Assert.AreEqual(expectedSchema, parsedAddress.SchemaName);
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
+++ b/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
@@ -20,6 +20,10 @@
                 var parts = address.Split('@');
                 var tableName = parts[0];
                 var schemaName = parts[1];
+                if (schemaName.StartsWith("[") && schemaName.EndsWith("]"))
+                {
+                    schemaName = schemaName.Substring(1, schemaName.Length - 2);
+                }
 
                 return new QueueAddress(tableName, schemaName);
             }
@@ -29,7 +33,14 @@
 
         public override string ToString()
         {
-            return $"{TableName}@{SchemaName}";
+            var escapedSchema = SchemaName ?? "";
+            if (!string.IsNullOrWhiteSpace(escapedSchema) && !(escapedSchema.StartsWith("[") && escapedSchema.EndsWith("]")))
+            {
+                escapedSchema = $"[{escapedSchema}]";
+            }
+            if (!string.IsNullOrWhiteSpace(escapedSchema))
+                escapedSchema = "@" + escapedSchema;
+            return $"{TableName}{escapedSchema}";
         }
     }
 }

--- a/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
+++ b/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
@@ -21,7 +21,7 @@
             {
                 var parts = address.Split('@');
                 var tableName = parts[0];
-                var schemaName = UnescapeSchema(parts[1]);
+                var schemaName = parts[1];
 
                 return new QueueAddress(tableName, schemaName);
             }
@@ -31,29 +31,31 @@
 
         public override string ToString()
         {
-            var escapedSchema = SchemaName ?? "";
-            if (!string.IsNullOrWhiteSpace(escapedSchema) && !IsEscapedSchema(escapedSchema))
+            if (!string.IsNullOrWhiteSpace(SchemaName))
             {
-                escapedSchema = $"[{escapedSchema}]";
+                return $"{TableName}@[{SchemaName}]";
             }
-            if (!string.IsNullOrWhiteSpace(escapedSchema))
-                escapedSchema = "@" + escapedSchema;
-            return $"{TableName}{escapedSchema}";
+
+            return TableName;
         }
 
         private static string UnescapeSchema(string schemaName)
         {
-            if (schemaName == null) return null;
             if (IsEscapedSchema(schemaName))
             {
                 return schemaName.Substring(1, schemaName.Length - 2);
             }
+
             return schemaName;
         }
 
         private static bool IsEscapedSchema(string schema)
         {
-            if (schema == null) return true;
+            if (schema == null)
+            {
+                return false;
+            }
+
             return Regex.IsMatch(schema, "^\\[(.*)\\]$");
         }
     }

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -165,12 +165,10 @@ namespace NServiceBus
 
             string schemaName;
 
-            if (logicalAddress.EndpointInstance.Properties.TryGetValue(SchemaPropertyKey, out schemaName))
-            {
-                address += $"@{schemaName}";
-            }
+            logicalAddress.EndpointInstance.Properties.TryGetValue(SchemaPropertyKey, out schemaName);
+            var queueAddress = new QueueAddress(address, schemaName);
 
-            return address;
+            return queueAddress.ToString();
         }
 
         /// <summary>

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -161,12 +161,12 @@ namespace NServiceBus
                 logicalAddress.EndpointInstance.Discriminator
             }.Where(p => !string.IsNullOrEmpty(p));
 
-            var address = string.Join(".", nonEmptyParts);
+            var tableName = string.Join(".", nonEmptyParts);
 
             string schemaName;
 
             logicalAddress.EndpointInstance.Properties.TryGetValue(SchemaPropertyKey, out schemaName);
-            var queueAddress = new QueueAddress(address, schemaName);
+            var queueAddress = new QueueAddress(tableName, schemaName);
 
             return queueAddress.ToString();
         }


### PR DESCRIPTION
Connects to #155 

This ensures the schema name in the queue address is escaped to help distinguish it from other components (e.g. catalog) when we add them in the future.