### PR TITLE
Prevent bumping of version on develop branch from commit message

### DIFF
--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -3,3 +3,4 @@ next-version: 3.0
 branches:
   develop:
     tag: alpha
+    prevent-increment-of-merged-branch-version: true


### PR DESCRIPTION
As being discussed here:

https://gitter.im/GitTools/GitVersion?at=5707bb02c65c9a6f7f27e913

With @danielmarbach, there is an issue with a Pull Request merge message causing an unrequired bump in the minor version number in this repository.

By making this change, you can prevent that from happening.

Once you have tagged the repo at 3.1.0, you can remove this change in case you actually want this going forward.

**NOTE:** in order to prove that this is working, make sure to empty the cached version number folder, just in case you are seeing pre-calculated versions.  You should always do this when making a change to the GitVersionConfig.yaml file, as you can get previous results.  The cache folder is here:

`.git\gitversion_cache`

in the repo checkout folder.

Hope this helps!