### PR TITLE
Deduplicate publish operations based on message ID and queue address

### DIFF
--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiApprover.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />
     <Compile Include="ConfigurationValidatorTests.cs" />
+    <Compile Include="Sending\MessageDispatcherTests.cs" />
     <Compile Include="QueueAddressTests.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -107,5 +108,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.SqlServer.UnitTests/Sending/MessageDispatcherTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/Sending/MessageDispatcherTests.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.SqlServer.UnitTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Routing;
+    using Transports;
+    using Transports.SQLServer;
+
+    [TestFixture]
+    public class MessageDispatcherTests
+    {
+        [TestCaseSource(nameof(TestCases))]
+        public async Task It_deduplicates_based_on_message_id_and_address(TransportOperations transportOperations, int expectedDispatchedMessageCount)
+        {
+            var queueDispatcher = new FakeTableBasedQueueDispatcher();
+
+            var dispatcher = new MessageDispatcher(queueDispatcher, new QueueAddressParser("dbo", null, s => null));
+
+            await dispatcher.Dispatch(transportOperations, new ContextBag());
+
+            Assert.AreEqual(expectedDispatchedMessageCount, queueDispatcher.DispatchedMessageIds.Count);
+        }
+
+        static object[] TestCases =
+        {
+            new object[]
+            {
+                new TransportOperations(
+                    CreateTransportOperations("1", "Destination@dbo"),
+                    CreateTransportOperations("1", "Destination")
+                ),
+                1
+            },
+            new object[]
+            {
+                new TransportOperations(
+                    CreateTransportOperations("1", "Destination@dbo"),
+                    CreateTransportOperations("1", "Destination@someSchema")
+                ),
+                2
+            },
+            new object[]
+            {
+                new TransportOperations(
+                    CreateTransportOperations("1", "Destination@dbo"),
+                    CreateTransportOperations("1", "Destination@someSchema"),
+                    CreateTransportOperations("1", "Destination")
+                ),
+                2
+            },
+            new object[]
+            {
+                new TransportOperations(
+                    CreateTransportOperations("1", "Destination@dbo"),
+                    CreateTransportOperations("2", "Destination")
+                ),
+                2
+            }
+        };
+
+        static TransportOperation CreateTransportOperations(string messageId, string destination)
+        {
+            return new TransportOperation(new OutgoingMessage(messageId, new Dictionary<string, string>(), new byte[0]), new UnicastAddressTag(destination));
+        }
+
+        class FakeTableBasedQueueDispatcher : TableBasedQueueDispatcher
+        {
+            public List<string> DispatchedMessageIds = new List<string>();
+
+            public FakeTableBasedQueueDispatcher() 
+                : base(null)
+            {
+            }
+
+            public override Task DispatchAsIsolated(List<MessageWithAddress> isolatedConsistencyOperations)
+            {
+                DispatchedMessageIds.AddRange(isolatedConsistencyOperations.Select(x => x.Message.MessageId));
+                return Task.FromResult(0);
+            }
+
+            public override Task DispatchOperationsWithNewConnectionAndTransaction(List<MessageWithAddress> defaultConsistencyOperations)
+            {
+                DispatchedMessageIds.AddRange(defaultConsistencyOperations.Select(x => x.Message.MessageId));
+                return Task.FromResult(0);
+            }
+
+            public override Task DispatchUsingReceiveTransaction(TransportTransaction transportTransaction, List<MessageWithAddress> defaultConsistencyOperations)
+            {
+                DispatchedMessageIds.AddRange(defaultConsistencyOperations.Select(x => x.Message.MessageId));
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Resharper.Annotations.g.cs" />
     <Compile Include="Sending\MessageDispatcher.cs" />
     <Compile Include="Configuration\SqlScopeOptions.cs" />
+    <Compile Include="Sending\TableBasedQueueDispatcher.cs" />
     <Compile Include="SqlServerTransport.cs" />
     <Compile Include="Receiving\MessagePump.cs" />
     <Compile Include="Queuing\MessageReadResult.cs" />

--- a/src/NServiceBus.SqlServer/Sending/TableBasedQueueDispatcher.cs
+++ b/src/NServiceBus.SqlServer/Sending/TableBasedQueueDispatcher.cs
@@ -1,0 +1,65 @@
+namespace NServiceBus.Transports.SQLServer
+{
+    using System.Collections.Generic;
+    using System.Data.SqlClient;
+    using System.Threading.Tasks;
+    using System.Transactions;
+
+    class TableBasedQueueDispatcher
+    {
+        SqlConnectionFactory connectionFactory;
+
+        public TableBasedQueueDispatcher(SqlConnectionFactory connectionFactory)
+        {
+            this.connectionFactory = connectionFactory;
+        }
+
+        public virtual async Task DispatchOperationsWithNewConnectionAndTransaction(List<MessageWithAddress> defaultConsistencyOperations)
+        {
+            using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
+            using (var transaction = connection.BeginTransaction())
+            {
+                foreach (var operation in defaultConsistencyOperations)
+                {
+                    var queue = new TableBasedQueue(operation.Address);
+
+                    await queue.SendMessage(operation.Message, connection, transaction).ConfigureAwait(false);
+                }
+
+                transaction.Commit();
+            }
+        }
+
+        public virtual async Task DispatchUsingReceiveTransaction(TransportTransaction transportTransaction, List<MessageWithAddress> defaultConsistencyOperations)
+        {
+            SqlConnection sqlTransportConnection;
+            SqlTransaction sqlTransportTransaction;
+
+            transportTransaction.TryGet(out sqlTransportConnection);
+            transportTransaction.TryGet(out sqlTransportTransaction);
+
+            foreach (var operation in defaultConsistencyOperations)
+            {
+                var queue = new TableBasedQueue(operation.Address);
+
+                await queue.SendMessage(operation.Message, sqlTransportConnection, sqlTransportTransaction).ConfigureAwait(false);
+            }
+        }
+
+        public virtual async Task DispatchAsIsolated(List<MessageWithAddress> isolatedConsistencyOperations)
+        {
+            using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+            using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
+            {
+                foreach (var operation in isolatedConsistencyOperations)
+                {
+                    var queue = new TableBasedQueue(operation.Address);
+
+                    await queue.SendMessage(operation.Message, connection, null).ConfigureAwait(false);
+                }
+
+                scope.Complete();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -123,7 +123,7 @@ namespace NServiceBus
             var connectionFactory = CreateConnectionFactory();
 
             return new TransportSendInfrastructure(
-                () => new MessageDispatcher(connectionFactory, addressParser),
+                () => new MessageDispatcher(new TableBasedQueueDispatcher(connectionFactory), addressParser),
                 () =>
                 {
                     var result = UsingV2ConfigurationChecker.Check();


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.SqlServer/issues/181

In order to prevent duplicate publishes when subscription store contains old V2 (schema-less) entries after upgrading publisher to V3.

This PR lacks proper unit testing of the deduplication behavior. This cannot be done currently because the dispatcher output (table queue) cannot be mocked. 

We should discuss unit testing the dispatcher before merging this.