### PR TITLE
InnerReceive yields to enforce asynchronous continuation to avoid costly synchronous connection pooling and enlistment on pump task.

### DIFF
--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -144,6 +144,10 @@
             {
                 try
                 {
+                    // We need to force the method to continue asynchronously because SqlConnection
+                    // in combination with TransactionScope will apply connection pooling and enlistment synchronous in ctor.
+                    await Task.Yield();
+
                     await receiveStrategy.ReceiveMessage(inputQueue, errorQueue, tokenSource, pipeline)
                         .ConfigureAwait(false);
 


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/732

Fixes #214 

This will increase performance of receives in order of magnitude on high latency scenarios but also low latency scenarios. On my machine I saw up to 6 times more throughput with Azure SQL S3.

Deeper analysis have shown that the `SqlConnection` constructor surrounded with a `TransactionScope` will do very costly operations synchronously on the calling thread such as [connection pooling](http://referencesource.microsoft.com/#System.Data/System/Data/ProviderBase/DbConnectionFactory.cs,208) and DTC enlistment.

## Reproduction Sample

Uses Sql.cs and MessageParser.cs from #211 

```
   internal class Program
    {
        private static void Main(string[] args)
        {
            var receives = new ConcurrentDictionary<Task, Task>();
            var stopwatch = Stopwatch.StartNew();
            var semaphore = new SemaphoreSlim(100);
            var runner = Task.Run(async () =>
            {
                for (var i = 0; i < 10000; i++)
                {
                    //Console.Write(i);
                    await semaphore.WaitAsync().ConfigureAwait(false);

#pragma warning disable 4014
                    var receive = Receive().ContinueWith(t =>
                    {
                        Task dummy;
                        receives.TryRemove(t, out dummy);
                        semaphore.Release();
                        Console.Write(".");
                    }, TaskContinuationOptions.ExecuteSynchronously);
                    receives.TryAdd(receive, receive);
#pragma warning restore 4014
                }
            });

            runner.Wait();
            Task.WaitAll(receives.Values.ToArray());
            stopwatch.Stop();

            Console.WriteLine(stopwatch.Elapsed);

            Console.ReadLine();
        }

        static async Task Receive()
        {
            using(var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled))
            using (
                var connection = new SqlConnection(@"SQL Connection string")
                )
            {
                await connection.OpenAsync().ConfigureAwait(false);
                using (var command = new SqlCommand(string.Format(Sql.ReceiveText, "dbo", "YourTable")))
                {
                    command.Connection = connection;

                    using (var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleRow | CommandBehavior.SequentialAccess).ConfigureAwait(false))
                    {
                        try
                        {
                            if (await reader.ReadAsync().ConfigureAwait(false))
                            {
                                var message = await MessageParser.ParseRawData(reader).ConfigureAwait(false);
                                Console.Write(message.TransportId.Substring(0,1));
                            }
                        }
                        catch (Exception ex)
                        {
                            Console.WriteLine(ex);
                            Console.Write("!");
                        }
                    }
                }

                tx.Complete();
            }
        }
    }
```

This code takes over roughly 270 seconds on my machine to process 10 k messages.

You can see the evil things that happen in the constructor and how it eats the pump thread in the following screenshots

![image](https://cloud.githubusercontent.com/assets/174258/14755918/e6a93ae6-08e5-11e6-9aa8-e3a9e48c445e.png)

Thread 3 is the pump thread. It pays the majority of the costs. Other threads will execute mostly the continuations.

![image](https://cloud.githubusercontent.com/assets/174258/14755938/0a99da0a-08e6-11e6-8558-c953b1eabd99.png)

## Solution

Super simple.

Enforce the code before opening the connection to yield asynchronously with [Task.Yield](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.yield(v=vs.110).aspx).

So the above shown code would look like this:

```
...
        static async Task Receive()
        {
            await Task.Yield();  // MAGIC HAPPENS HERE ;)

            using(var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled))
            using (
                var connection = new SqlConnection(@"SQL Connection string")
                )
            {

...
```

For all nitpickers. `Task.Yield` doesn't provide `ConfigureAwait` ;)

Then the code is able to process 10K messages in 38 seconds on my machine.

An the profiler results looks like

Work is evenly distributed (more or less ;) )

![image](https://cloud.githubusercontent.com/assets/174258/14756076/1cebf020-08e7-11e6-87e9-fe23f4061844.png)

all involved threads will open up connections

![image](https://cloud.githubusercontent.com/assets/174258/14756063/0e67e9b4-08e7-11e6-9ef4-e9af5c85535b.png)

## Applied to NServiceBus.SqlServer with Sql Azure S3

### Before

```
Concurrency 100, 10 K Messages
Initalizing the bus took 0:00:00:01.5956504
Receiving #10000 of msgs over the bus took 0:00:04:11.7019003
```

### After

```
Concurrency 100, 10 K Messages
Initalizing the bus took 0:00:00:01.6650525
Receiving #10000 of msgs over the bus took 0:00:00:40.3449894
```

## Readings
 * [When to use Task.Yield](http://stackoverflow.com/questions/22645024/when-would-i-use-task-yield)