### PR TITLE
Opt out from waiting for DONE_IN_PROC messages by setting NO COUNT ON for statements that don't need it

### DIFF
--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -5,13 +5,27 @@ namespace NServiceBus.Transport.SQLServer
         internal const string PurgeText = "DELETE FROM {0}.{1}";
 
         internal const string SendText =
-            @"INSERT INTO {0}.{1} ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body])
-                                    VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,CASE WHEN @TimeToBeReceivedMs IS NOT NULL THEN DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()) END,@Headers,@Body)";
+            @"
+              DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
+              IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
+              SET NOCOUNT ON;
 
-        internal const string ReceiveText =
-            @"WITH message AS (SELECT TOP(1) * FROM {0}.{1} WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] IS NULL OR [Expires] > GETUTCDATE() ORDER BY [RowVersion])
-			DELETE FROM message
-			OUTPUT deleted.Id, deleted.CorrelationId, deleted.ReplyToAddress, deleted.Recoverable, deleted.Headers, deleted.Body;";
+              INSERT INTO {0}.{1} ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body])
+              VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,CASE WHEN @TimeToBeReceivedMs IS NOT NULL THEN DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()) END,@Headers,@Body);;
+
+              IF(@NOCOUNT = 'ON') SET NOCOUNT ON;
+              IF(@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
+
+        internal const string ReceiveText = @"
+            DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
+            IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
+            SET NOCOUNT ON;
+
+            WITH message AS (SELECT TOP(1) * FROM {0}.{1} WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] IS NULL OR [Expires] > GETUTCDATE() ORDER BY [RowVersion])
+            DELETE FROM message
+            OUTPUT deleted.Id, deleted.CorrelationId, deleted.ReplyToAddress, deleted.Recoverable, deleted.Headers, deleted.Body;
+            IF(@NOCOUNT = 'ON') SET NOCOUNT ON;
+            IF(@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
         internal const string PeekText = "SELECT count(*) Id FROM {0}.{1} WITH (READPAST) WHERE [Expires] IS NULL OR [Expires] > GETUTCDATE();";
 
@@ -22,24 +36,24 @@ namespace NServiceBus.Transport.SQLServer
                     IF NOT  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[{0}].[{1}]') AND type in (N'U'))
                     BEGIN
                         CREATE TABLE [{0}].[{1}](
-	                        [Id] [uniqueidentifier] NOT NULL,
-	                        [CorrelationId] [varchar](255) NULL,
-	                        [ReplyToAddress] [varchar](255) NULL,
-	                        [Recoverable] [bit] NOT NULL,
-	                        [Expires] [datetime] NULL,
-	                        [Headers] [varchar](max) NOT NULL,
-	                        [Body] [varbinary](max) NULL,
-	                        [RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+                            [Id] [uniqueidentifier] NOT NULL,
+                            [CorrelationId] [varchar](255) NULL,
+                            [ReplyToAddress] [varchar](255) NULL,
+                            [Recoverable] [bit] NOT NULL,
+                            [Expires] [datetime] NULL,
+                            [Headers] [varchar](max) NOT NULL,
+                            [Body] [varbinary](max) NULL,
+                            [RowVersion] [bigint] IDENTITY(1,1) NOT NULL
                         ) ON [PRIMARY];
 
                         CREATE CLUSTERED INDEX [Index_RowVersion] ON [{0}].[{1}]
                         (
-	                        [RowVersion] ASC
+                            [RowVersion] ASC
                         )WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
 
                         CREATE NONCLUSTERED INDEX [Index_Expires] ON [{0}].[{1}]
                         (
-	                        [Expires] ASC
+                            [Expires] ASC
                         )
                         INCLUDE
                         (


### PR DESCRIPTION
Connects to: #231 

Caveat first: This might be an esoteric change.

NO COUNT ON: Stops the message that shows the count of the number of rows affected by a Transact-SQL statement or stored procedure from being returned as part of the result set.

[Official MS statement](https://msdn.microsoft.com/en-us/library/ms189837.aspx)

> SET NOCOUNT ON prevents the sending of DONE_IN_PROC messages to the client for each statement in a stored procedure. For stored procedures that contain several statements that do not return much actual data, or for procedures that contain Transact-SQL loops, setting SET NOCOUNT to ON can provide a significant performance boost, because network traffic is greatly reduced.

Although detailed analysis[ from Dale on his blogs ](http://daleburnett.com/2014/01/everything-ever-wanted-know-set-nocount/)shows that

> The documentation claims that setting NOCOUNT on can have significant network bandwidth savings. As we can see this is on a case-by-case basis determined by the number of non-data returning statements being executed relative to the amount of results returned. A WHILE loop that executes 10,000 times in a procedure that only returns one row will see a great reduction in traffic relative to the size of the entire result set. But a few non-data returning statements in a batch that returns thousands and thousands of rows will see practically zero percentage change in bandwidth.

## WITH NOCOUNT OFF

![image](https://cloud.githubusercontent.com/assets/174258/15180497/51b23df6-1782-11e6-966f-b963153be4fe.png)

## WITH NOCOUNT ON

![image](https://cloud.githubusercontent.com/assets/174258/15180503/5e67343e-1782-11e6-8598-9c2d2e761c24.png)


Costs of the call are non-existing so I don't think it would hurt.

![image](https://cloud.githubusercontent.com/assets/174258/15180374/8346e70a-1781-11e6-8fc4-9d7ec998d1a0.png)

Permissions: Requires membership in the public role.

Local analysis shows not big of a difference. We would need to test with higher latency though

https://docs.google.com/a/nservicebus.com/spreadsheets/d/13v7llKhqZgNpU-_7KT76pZvd-ke8TXnigFsu1DbS_qw/edit?usp=sharing

### Sends

![image](https://cloud.githubusercontent.com/assets/174258/15180418/cc422230-1781-11e6-8ab4-ca700b6bb2c7.png)

### Receives

![image](https://cloud.githubusercontent.com/assets/174258/15180430/da77b3d8-1781-11e6-8c1b-f1a0929ddfec.png)


## Readings

- https://msdn.microsoft.com/en-us/library/ms189837.aspx
- https://msdn.microsoft.com/en-us/library/dd340553.aspx
- http://daleburnett.com/2014/01/everything-ever-wanted-know-set-nocount/