### PR TITLE
Early closing of SQL connection in the ambient transaction mode.

### DIFF
--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
@@ -43,8 +43,9 @@
                 using (var pushCancellationTokenSource = new CancellationTokenSource())
                 using (var bodyStream = message.BodyStream)
                 {
+                    connection.Close();
+
                     var transportTransaction = new TransportTransaction();
-                    transportTransaction.Set(connection);
                     transportTransaction.Set(Transaction.Current);
 
                     var pushContext = new PushContext(message.TransportId, message.Headers, bodyStream, transportTransaction, pushCancellationTokenSource, new ContextBag());


### PR DESCRIPTION
Closing the SQL connection before invoking the pipe allows other things in the pipe (e.g. persistence) that use the same `TransactionScope` to open their connections without necessarily escalating to DTC (if both connections have the same connection string). The flow would be following:

1. Create `TransactionScope`
1. Open transport connection
1. Receive message
1. Close transport connection
1. Execute the pipe
1. Open persistence connection
1. Handle the message
  1. Enqueue message to be sent (batching)
  1. Open immediate dispatch `TransactionScope`
    1. Open immediate dispatch connection
    1. Send the message
    1. Close the immediate dispatch connection
  1. Dispose immediate dispatch `TransactionScope`
1. Close persistence connection
1. Open batch dispatch connection
1. Send batched messages
1. Close batch dispatch connection
1. Dispose transport `TransactionScope`

NOTE: Because the connection is closed early, there is no way for a handler to get that connection. But this should not be an issue because the handler is free to open its own connection and, if the connection string matches, it would not cause DTC escalation.

[here](https://github.com/Particular/docs.particular.net/pull/1594) a doco pull that assumes this is merged and provides info how to handle handlers that access the transport connection during 2->3 upgrade.