### PR TITLE
Avoiding allocations with Task.ContinueWith by opting-in for delegate caching

### DIFF
--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -131,11 +131,12 @@
                     var receiveTask = InnerReceive(loopCancellationTokenSource);
                     runningReceiveTasks.TryAdd(receiveTask, receiveTask);
 
-                    receiveTask.ContinueWith(t =>
+                    receiveTask.ContinueWith((t, state) =>
                     {
+                        var receiveTasks = (ConcurrentDictionary<Task, Task>) state;
                         Task toBeRemoved;
-                        runningReceiveTasks.TryRemove(t, out toBeRemoved);
-                    }, TaskContinuationOptions.ExecuteSynchronously)
+                        receiveTasks.TryRemove(t, out toBeRemoved);
+                    }, runningReceiveTasks, TaskContinuationOptions.ExecuteSynchronously)
                     .Ignore();
                 }
             }


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus/issues/3883