### PR TITLE
SQL injection vulnerability

### DIFF
--- a/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
+++ b/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
@@ -116,12 +116,13 @@
 
         static string SendSqlCommandText(string schemaName, Address address)
         {
-            var sanitizer = new SqlCommandBuilder();
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                var quotedSchema = sanitizer.QuoteIdentifier(schemaName);
+                var quotedTable = sanitizer.QuoteIdentifier(TableNameUtils.GetTableName(address));
 
-            var quotedSchema = sanitizer.QuoteIdentifier(schemaName);
-            var quotedTable = sanitizer.QuoteIdentifier(TableNameUtils.GetTableName(address));
-
-            return string.Format(SqlSend, quotedSchema, quotedTable);
+                return string.Format(SqlSend, quotedSchema, quotedTable);
+            }
         }
 
         private static void ThrowFailedToSendException(Address address, Exception ex)

--- a/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
+++ b/src/NServiceBus.SqlServer/SqlServerMessageSender.cs
@@ -15,7 +15,7 @@
     public class SqlServerMessageSender : ISendMessages
     {
         const string SqlSend =
-            @"INSERT INTO [{0}].[{1}] ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body]) 
+            @"INSERT INTO {0}.{1} ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body])
                                     VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,@Expires,@Headers,@Body)";
 
         static JsonMessageSerializer Serializer = new JsonMessageSerializer(null);
@@ -71,7 +71,7 @@
                     //if there is an active transaction for the connection, we can use the same native transaction
                     var transaction = UnitOfWork.GetTransaction(queueConnectionString);
 
-                    using (var command = new SqlCommand(string.Format(SqlSend, schemaName, TableNameUtils.GetTableName(address)), transaction.Connection, transaction)
+                    using (var command = new SqlCommand(SendSqlCommandText(schemaName, address), transaction.Connection, transaction)
                         {
                             CommandType = CommandType.Text
                         })
@@ -85,7 +85,7 @@
                     using (var connection = new SqlConnection(queueConnectionString))
                     {
                         connection.Open();
-                        using (var command = new SqlCommand(string.Format(SqlSend, schemaName, TableNameUtils.GetTableName(address)), connection)
+                        using (var command = new SqlCommand(SendSqlCommandText(schemaName, address), connection)
                             {
                                 CommandType = CommandType.Text
                             })
@@ -114,6 +114,15 @@
             }
         }
 
+        static string SendSqlCommandText(string schemaName, Address address)
+        {
+            var sanitizer = new SqlCommandBuilder();
+
+            var quotedSchema = sanitizer.QuoteIdentifier(schemaName);
+            var quotedTable = sanitizer.QuoteIdentifier(TableNameUtils.GetTableName(address));
+
+            return string.Format(SqlSend, quotedSchema, quotedTable);
+        }
 
         private static void ThrowFailedToSendException(Address address, Exception ex)
         {

--- a/src/NServiceBus.SqlServer/SqlServerPollingDequeueStrategy.cs
+++ b/src/NServiceBus.SqlServer/SqlServerPollingDequeueStrategy.cs
@@ -63,10 +63,11 @@
                 Timeout = transactionSettings.TransactionTimeout
             };
 
-            var sanitizer = new SqlCommandBuilder();
-
-            quotedSchemaName = sanitizer.QuoteIdentifier(SchemaName);
-            quotedTableName = sanitizer.QuoteIdentifier(TableNameUtils.GetTableName(address));
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                quotedSchemaName = sanitizer.QuoteIdentifier(SchemaName);
+                quotedTableName = sanitizer.QuoteIdentifier(TableNameUtils.GetTableName(address));
+            }
 
             sql = string.Format(SqlReceive, quotedSchemaName, quotedTableName);
 


### PR DESCRIPTION
### Vulnerability

All versions of the SQL Server transport use string interpolation to assemble queue table names. Some inputs may come from untrusted sources, for instance the `ReplyToAddress` message header. This may allow attacker to craft a message in such a way that arbitrary SQL is executed on the database.

### Impact

Attackers can use this vulnerability to force an NServiceBus endpoint to execute arbitrary SQL statements against the SQL Server database that stores its input queue.

### Exploitability

The exploitation of this vulnerability requires that all of the conditions below are met at the same time:
 1. An attacker must have the ability to send a malicious message to an endpoint OR an attacker must be able to modify a message that is in transit to an endpoint such that the `ReplyToAddress` header can be manipulated,
 1. The receiving endpoint sends a message based on `ReplyToAddress` header

### Affected versions

All versions of the NServiceBus SQL Server Transport, up to and including 3.0.0-beta0002, are affected by this vulnerability.

This PR resolves the issue for NServiceBus SQL Server Transport versions 1.x.

### Risk Mitigation

If you are unable to upgrade your endpoints that are using the SQL Server Transport, the following can be used as a **temporary workaround:**
 * Stop all endpoints that send a message based on the `ReplyToAddress`

### Resolution

Schema and name of the queue table can be properly quoted using the [`SqlCommandBuilder.QuoteIdentifier`](https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommandbuilder.quoteidentifier.aspx) method. 

Connects to Particular/PlatformDevelopment#831
Fixes #272 