### PR TITLE
SQL injection vulnerability

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.6\Volatile\When_sending_to_non_durable_endpoint.cs" />
     <Compile Include="When_in_native_transaction_mode.cs" />
     <Compile Include="When_processing_messages.cs" />
+    <Compile Include="When_ReplyTo_address_does_not_exist.cs" />
     <Compile Include="When_using_non_standard_schema.cs" />
     <Compile Include="When_callback_receiver_is_disabled.cs" />
     <Compile Include="When_using_different_connection_strings_for_each_endpoint.cs" />

--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_ReplyTo_address_does_not_exist.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_ReplyTo_address_does_not_exist.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Faults;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_ReplyTo_address_does_not_exist
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<Attacker>(b => b.When(bus => bus.SendLocal(new StartCommand())))
+                .WithEndpoint<Victim>()
+                .AllowExceptions()
+                .Done(c => c.ExceptionReceived)
+                .Run();
+
+            Assert.That(context.ExceptionMessage, Contains.Substring("The destination queue") & Contains.Substring("could not be found"));
+            Assert.That(context.ExceptionMessage, Contains.Substring("error] VALUES(NEWID(), NULL, NULL, 1, NULL, '', NULL); DROP TABLE [Victim]; INSERT INTO [error"));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool ExceptionReceived { get; set; }
+            public string ExceptionMessage { get; set; }
+        }
+
+        class Attacker : EndpointConfigurationBuilder
+        {
+            public Attacker()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<SqlServerTransport>()
+                        .DisableCallbackReceiver();
+                    c.OverridePublicReturnAddress(Address.Parse("error] VALUES(NEWID(), NULL, NULL, 1, NULL, '', NULL); DROP TABLE [Victim]; INSERT INTO [error"));
+                })
+                    .AddMapping<AttackCommand>(typeof(Victim));
+            }
+
+            class StartHandler : IHandleMessages<StartCommand>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(StartCommand message)
+                {
+                    Bus.Send(new AttackCommand());
+                }
+            }
+
+            class AttackResponseHandler : IHandleMessages<AttackResponse>
+            {
+                public void Handle(AttackResponse message)
+                {
+                }
+            }
+        }
+
+        class Victim : EndpointConfigurationBuilder
+        {
+            public Victim()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.RegisterComponents(c => c.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance));
+                    b.DisableFeature<TimeoutManager>();
+                })
+                    .WithConfig<TransportConfig>(c => c.MaxRetries = 0);
+            }
+
+            class AttackHandler : IHandleMessages<AttackCommand>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(AttackCommand message)
+                {
+                    Bus.Reply(new AttackResponse());
+                }
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.ExceptionMessage = e.Message;
+                    Context.ExceptionReceived = true;
+                }
+
+                public void Init(Address address)
+                {
+                }
+            }
+        }
+
+        class StartCommand : ICommand
+        {
+        }
+
+        class AttackCommand : ICommand
+        {
+        }
+
+        class AttackResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AdaptiveExecutorSimulator\Simulations.cs" />
     <Compile Include="SqlConnectionFactoryConfigTests.cs" />
+    <Compile Include="TableBasedQueueTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NServiceBus.snk" />

--- a/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
@@ -9,7 +9,7 @@
         public void Table_name_and_schema_should_be_quoted()
         {
             Assert.AreEqual("[nsb].[MyEndpoint]", new TableBasedQueue("MyEndpoint", "nsb").ToString());
-            Assert.AreNotEqual("[nsb].[MyEndoint]SomeOtherData]", new TableBasedQueue("MyEndoint]SomeOtherData", "nsb").ToString());
+            Assert.AreEqual("[nsb].[MyEndoint]]; SOME OTHER SQL;--]", new TableBasedQueue("MyEndoint]; SOME OTHER SQL;--", "nsb").ToString());
         }
     }
 }

--- a/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.SqlServer.UnitTests
+{
+    using NServiceBus.Transports.SQLServer;
+    using NUnit.Framework;
+
+    class TableBasedQueueTests
+    {
+        [Test]
+        public void Table_name_and_schema_should_be_quoted()
+        {
+            Assert.AreEqual("[nsb].[MyEndpoint]", new TableBasedQueue("MyEndpoint", "nsb").ToString());
+            Assert.AreNotEqual("[nsb].[MyEndoint]SomeOtherData]", new TableBasedQueue("MyEndoint]SomeOtherData", "nsb").ToString());
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/TableBasedQueue.cs
@@ -17,10 +17,11 @@ namespace NServiceBus.Transports.SQLServer
 
         public TableBasedQueue(string tableName, string schema)
         {
-            var sanitizer = new SqlCommandBuilder();
-
-            this.tableName = sanitizer.QuoteIdentifier(tableName);
-            this.schema = sanitizer.QuoteIdentifier(schema);
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                this.tableName = sanitizer.QuoteIdentifier(tableName);
+                this.schema = sanitizer.QuoteIdentifier(schema);
+            }
         }
 
         public void Send(TransportMessage message, SendOptions sendOptions, SqlConnection connection, SqlTransaction transaction = null)


### PR DESCRIPTION
### Vulnerability

All versions of the SQL Server transport use string interpolation to assemble queue table names. Some inputs may come from untrusted sources, for instance the `ReplyToAddress` message header. This may allow attacker to craft a message in such a way that arbitrary SQL is executed on the database.

### Impact

Attackers can use this vulnerability to force an NServiceBus endpoint to execute arbitrary SQL statements against the SQL Server database that stores its input queue.

### Exploitability

The exploitation of this vulnerability requires that all of the conditions below are met at the same time:
 1. An attacker must have the ability to send a malicious message to an endpoint OR an attacker must be able to modify a message that is in transit to an endpoint such that the `ReplyToAddress` header can be manipulated,
 1. The receiving endpoint sends a message based on `ReplyToAddress` header

### Affected versions

All versions of the NServiceBus SQL Server Transport, up to and including 3.0.0-beta0002, are affected by this vulnerability.

This PR resolves the issue for NServiceBus SQL Server Transport versions 2.x.

### Risk Mitigation

If you are unable to upgrade your endpoints that are using the SQL Server Transport, the following can be used as a **temporary workaround:**
 * Stop all endpoints that send a message based on the `ReplyToAddress`

### Resolution

Schema and name of the queue table can be properly quoted using the [`SqlCommandBuilder.QuoteIdentifier`](https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommandbuilder.quoteidentifier.aspx) method. 

Connects to Particular/PlatformDevelopment#831
Resolves #272 