### PR TITLE
SQL injection vulnerability

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
@@ -41,10 +41,13 @@ public class ConfigureEndpointSqlServerTransport : IConfigureEndpointTestExecuti
                 var nameParts = n.Split('@');
                 if (nameParts.Length == 2)
                 {
-                    var sanitizedSchemaName = SanitizeIdentifier(nameParts[1]);
-                    var sanitizedTableName = SanitizeIdentifier(nameParts[0]);
+                    using (var sanitizer = new SqlCommandBuilder())
+                    {
+                        var sanitizedSchemaName = SanitizeIdentifier(nameParts[1], sanitizer);
+                        var sanitizedTableName = SanitizeIdentifier(nameParts[0], sanitizer);
 
-                    queueNames.Add($"{sanitizedSchemaName}.{sanitizedTableName}");
+                        queueNames.Add($"{sanitizedSchemaName}.{sanitizedTableName}");
+                    }
                 }
                 else
                 {
@@ -64,13 +67,11 @@ public class ConfigureEndpointSqlServerTransport : IConfigureEndpointTestExecuti
         return Task.FromResult(0);
     }
 
-    string SanitizeIdentifier(string identifier)
+    static string SanitizeIdentifier(string identifier, SqlCommandBuilder sanitizer)
     {
         // Identifier may initially quoted or unquoted.
         return sanitizer.QuoteIdentifier(sanitizer.UnquoteIdentifier(identifier));
     }
-
-    readonly SqlCommandBuilder sanitizer = new SqlCommandBuilder();
 
     string connectionString;
     QueueBindings queueBindings;

--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -282,6 +282,7 @@
     <Compile Include="LegacyMultiInstance\When_using_legacy_multiinstance_mode_with_custom_schema.cs" />
     <Compile Include="LegacyMultiInstance\When_using_legacy_multiinstance_with_transaction_mode_different_from_distributed.cs" />
     <Compile Include="MultiSchema\When_custom_schema_configured_with_bracketed_transport_discriminator.cs" />
+    <Compile Include="When_ReplyTo_address_does_not_exist.cs" />
     <Compile Include="When_the_message_contains_a_legacy_callback_header.cs" />
     <Compile Include="Configuration\AppConfig.cs" />
     <Compile Include="ConfigureEndpointSqlServerTransport.cs" />

--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_ReplyTo_address_does_not_exist.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_ReplyTo_address_does_not_exist.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_ReplyTo_address_does_not_exist : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(async () =>
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Attacker>(b => b.When(session => session.SendLocal(new StartCommand())))
+                    .WithEndpoint<Victim>()
+                    .Done(c => c.FailedMessages.Any())
+                    .Run())
+                .ExpectFailedMessages();
+
+            Assert.That(exception.FailedMessages, Has.Count.EqualTo(1));
+
+            var failedMessage = exception.FailedMessages.Single();
+
+            Assert.That(failedMessage.Exception.Message, Contains.Substring("Failed to send message to"));
+            Assert.That(failedMessage.Exception.Message, Contains.Substring("error]] VALUES(NEWID(), NULL, NULL, 1, NULL, '', NULL); DROP TABLE [Victim]]; INSERT INTO [error"));
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class Attacker : EndpointConfigurationBuilder
+        {
+            public Attacker()
+            {
+                EndpointSetup<DefaultServer>(b => b.OverridePublicReturnAddress("error] VALUES(NEWID(), NULL, NULL, 1, NULL, '', NULL); DROP TABLE [Victim]; INSERT INTO [error"))
+                    .AddMapping<AttackCommand>(typeof(Victim));
+            }
+
+            class StartHandler : IHandleMessages<StartCommand>
+            {
+                public Task Handle(StartCommand message, IMessageHandlerContext context)
+                {
+                    return context.Send(new AttackCommand());
+                }
+            }
+
+            class AttackResponseHandler : IHandleMessages<AttackResponse>
+            {
+                public Task Handle(AttackResponse message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class Victim : EndpointConfigurationBuilder
+        {
+            public Victim()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AttackHandler : IHandleMessages<AttackCommand>
+            {
+                public Task Handle(AttackCommand message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new AttackResponse());
+                }
+            }
+        }
+
+        class StartCommand : ICommand
+        {
+        }
+
+        class AttackCommand : ICommand
+        {
+        }
+
+        class AttackResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -18,7 +18,7 @@
             var successfulReceives = 46;
             var queueSize = 1000;
 
-            var inputQueue = new FakeTableBasedQueue(QueueAddress.Parse("dbo.input"), queueSize, successfulReceives);
+            var inputQueue = new FakeTableBasedQueue(QueueAddress.Parse("input@dbo"), queueSize, successfulReceives);
 
             var pump = new MessagePump(
                 m => new ReceiveWithNoTransaction(sqlConnectionFactory),

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="ConfigurationValidatorTests.cs" />
     <Compile Include="Sending\MessageDispatcherTests.cs" />
     <Compile Include="QueueAddressTests.cs" />
+    <Compile Include="TableBasedQueueTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/TableBasedQueueTests.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.SqlServer.UnitTests
+{
+    using NUnit.Framework;
+    using Transport.SQLServer;
+
+    class TableBasedQueueTests
+    {
+        [Test]
+        public void Table_name_and_schema_should_be_quoted()
+        {
+            Assert.AreEqual("[nsb].[MyEndpoint]", new TableBasedQueue(new QueueAddress("MyEndpoint", "nsb")).ToString());
+            Assert.AreEqual("[nsb].[MyEndoint]]; SOME OTHER SQL;--]", new TableBasedQueue(new QueueAddress("MyEndoint]; SOME OTHER SQL;--", "nsb")).ToString());
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
+++ b/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
@@ -46,7 +46,10 @@
                 return schemaName;
             }
 
-            return new SqlCommandBuilder().UnquoteIdentifier(schemaName);
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                return sanitizer.UnquoteIdentifier(schemaName);
+            }
         }
     }
 }

--- a/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
+++ b/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
-    using System.Text.RegularExpressions;
+    using System.Data.SqlClient;
 
     class QueueAddress
     {
@@ -41,22 +41,12 @@
 
         static string UnescapeSchema(string schemaName)
         {
-            if (IsEscapedSchema(schemaName))
+            if (string.IsNullOrWhiteSpace(schemaName))
             {
-                return schemaName.Substring(1, schemaName.Length - 2);
+                return schemaName;
             }
 
-            return schemaName;
-        }
-
-        static bool IsEscapedSchema(string schema)
-        {
-            if (schema == null)
-            {
-                return false;
-            }
-
-            return Regex.IsMatch(schema, "^\\[(.*)\\]$");
+            return new SqlCommandBuilder().UnquoteIdentifier(schemaName);
         }
     }
 }

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -2,19 +2,19 @@ namespace NServiceBus.Transport.SQLServer
 {
     class Sql
     {
-        internal const string PurgeText = "DELETE FROM [{0}].[{1}]";
+        internal const string PurgeText = "DELETE FROM {0}.{1}";
 
         internal const string SendText =
-            @"INSERT INTO [{0}].[{1}] ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body])
+            @"INSERT INTO {0}.{1} ([Id],[CorrelationId],[ReplyToAddress],[Recoverable],[Expires],[Headers],[Body])
                                     VALUES (@Id,@CorrelationId,@ReplyToAddress,@Recoverable,CASE WHEN @TimeToBeReceivedMs IS NOT NULL THEN DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()) END,@Headers,@Body)";
 
         internal const string ReceiveText =
-            @"WITH message AS (SELECT TOP(1) * FROM [{0}].[{1}] WITH (UPDLOCK, READPAST, ROWLOCK) ORDER BY [RowVersion])
+            @"WITH message AS (SELECT TOP(1) * FROM {0}.{1} WITH (UPDLOCK, READPAST, ROWLOCK) ORDER BY [RowVersion])
 			DELETE FROM message
 			OUTPUT deleted.Id, deleted.CorrelationId, deleted.ReplyToAddress,
 			deleted.Recoverable, CASE WHEN deleted.Expires IS NOT NULL THEN DATEDIFF(ms, GETUTCDATE(), deleted.Expires) END, deleted.Headers, deleted.Body;";
 
-        internal const string PeekText = "SELECT count(*) Id FROM [{0}].[{1}] WITH (READPAST)";
+        internal const string PeekText = "SELECT count(*) Id FROM {0}.{1} WITH (READPAST)";
 
         internal const string CreateQueueText = @"IF NOT  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[{0}].[{1}]') AND type in (N'U'))
                   BEGIN
@@ -53,9 +53,9 @@ namespace NServiceBus.Transport.SQLServer
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
-        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM [{1}].[{2}] WHERE [Id] IN (SELECT TOP ({0}) [Id] FROM [{1}].[{2}] WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE() ORDER BY [RowVersion])";
+        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM {1}.{2} WHERE [Id] IN (SELECT TOP ({0}) [Id] FROM {1}.{2} WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE() ORDER BY [RowVersion])";
 
-        internal const string CheckIfExpiresIndexIsPresent = @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('[{1}].[{2}]')";
+        internal const string CheckIfExpiresIndexIsPresent = @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('{1}.{2}')";
 
         internal const string ExpiresIndexName = "Index_Expires";
     }

--- a/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
@@ -14,10 +14,11 @@ namespace NServiceBus.Transport.SQLServer
     {
         public TableBasedQueue(QueueAddress address)
         {
-            var sanitizer = new SqlCommandBuilder();
-
-            tableName = sanitizer.QuoteIdentifier(address.TableName);
-            schemaName = sanitizer.QuoteIdentifier(address.SchemaName);
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                tableName = sanitizer.QuoteIdentifier(address.TableName);
+                schemaName = sanitizer.QuoteIdentifier(address.SchemaName);
+            }
 
             TransportAddress = address.ToString();
         }


### PR DESCRIPTION
### Vulnerability

All versions of the SQL Server transport use string interpolation to assemble queue table names. Some inputs may come from untrusted sources, for instance the `ReplyToAddress` message header. This may allow attacker to craft a message in such a way that arbitrary SQL is executed on the database.

### Impact

Attackers can use this vulnerability to force an NServiceBus endpoint to execute arbitrary SQL statements against the SQL Server database that stores its input queue.

### Exploitability

The exploitation of this vulnerability requires that all of the conditions below are met at the same time:
 1. An attacker must have the ability to send a malicious message to an endpoint OR an attacker must be able to modify a message that is in transit to an endpoint such that the `ReplyToAddress` header can be manipulated,
 1. The receiving endpoint sends a message based on `ReplyToAddress` header

### Affected versions

All versions of the NServiceBus SQL Server Transport, up to and including 3.0.0-beta0002, are affected by this vulnerability.

This PR resolves the issue for NServiceBus SQL Server Transport versions 3.x.

### Risk Mitigation

If you are unable to upgrade your endpoints that are using the SQL Server Transport, the following can be used as a **temporary workaround:**
 * Stop all endpoints that send a message based on the `ReplyToAddress`

### Resolution

Schema and name of the queue table can be properly quoted using the [`SqlCommandBuilder.QuoteIdentifier`](https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommandbuilder.quoteidentifier.aspx) method. 

Connects to Particular/PlatformDevelopment#831
Resolves #272 