### PR TITLE
Canonic form of tablename in transport address

### DIFF
--- a/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/QueueAddressTests.cs
@@ -12,7 +12,7 @@
         [TestCase("table", "", "table")]
         [TestCase("table", null, "table")]
         [TestCase("table", "[my.schema]", "table@[my.schema]")]
-        [TestCase("[my.table]", "[my.schema]", "[my.table]@[my.schema]")]
+        [TestCase("my.table", "[my.schema]", "my.table@[my.schema]")]
         public void Should_include_brackets_around_schema_name(string tableName, string schemaName, string expectedAddress)
         {
             var address = new QueueAddress(tableName, schemaName);
@@ -26,7 +26,7 @@
         [TestCase("my.table@my.schema@my.schema", "my.table", "my.schema")]
         [TestCase("table", "table", null)]
         [TestCase("table@[my.schema]", "table", "my.schema")]
-        [TestCase("[my.table]@[my.schema]", "[my.table]", "my.schema")]
+        [TestCase("my.table@[my.schema]", "my.table", "my.schema")]
         public void Should_parse_address(string transportAddress, string expectedTableName, string expectedSchema)
         {
             var parsedAddress = QueueAddress.Parse(transportAddress);

--- a/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
+++ b/src/NServiceBus.SqlServer/Addressing/QueueAddress.cs
@@ -8,8 +8,8 @@
         {
             Guard.AgainstNullAndEmpty(nameof(tableName), tableName);
 
-            TableName = tableName;
-            SchemaName = UnescapeSchema(schemaName);
+            TableName = UnescapeIdentifier(tableName);
+            SchemaName = UnescapeIdentifier(schemaName);
         }
 
         public string TableName { get; }
@@ -39,16 +39,16 @@
             return TableName;
         }
 
-        static string UnescapeSchema(string schemaName)
+        static string UnescapeIdentifier(string identifier)
         {
-            if (string.IsNullOrWhiteSpace(schemaName))
+            if (string.IsNullOrWhiteSpace(identifier))
             {
-                return schemaName;
+                return identifier;
             }
 
             using (var sanitizer = new SqlCommandBuilder())
             {
-                return sanitizer.UnquoteIdentifier(schemaName);
+                return sanitizer.UnquoteIdentifier(identifier);
             }
         }
     }


### PR DESCRIPTION
Fixes #263 

I've monkey patched backwards compatibility tests and they are green as well.

/cc: @Particular/sqlserver-transport-maintainers 
