### PR TITLE
[SPIKE] Native timeouts

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-rc0001/Recoverability/Retries/When_immediate_retries_with_dtc_on.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-rc0001/Recoverability/Retries/When_immediate_retries_with_dtc_on.cs
@@ -55,7 +55,7 @@
                     b.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => scenarioContext.GaveUpOnRetries = true;
                     var recoverability = b.Recoverability();
                     recoverability.Immediate(settings => settings.NumberOfRetries(maxretries));
-                    recoverability.Delayed(settings => settings.TimeIncrease(TimeSpan.FromMilliseconds(1)).NumberOfRetries(3));
+                    recoverability.Delayed(settings => settings.TimeIncrease(TimeSpan.FromMilliseconds(1)).NumberOfRetries(0));
                 });
             }
 

--- a/src/NServiceBus.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
@@ -13,7 +13,9 @@ public class ConfigureScenariosForSqlServerTransport : IConfigureSupportedScenar
 {
     public IEnumerable<Type> UnsupportedScenarioDescriptorTypes { get; } = new[]
     {
-        typeof(AllTransportsWithCentralizedPubSubSupport)
+        typeof(AllTransportsWithCentralizedPubSubSupport),
+        typeof(AllTransportsWithoutNativeDeferral),
+        typeof(AllTransportsWithoutNativeDeferralAndWithAtomicSendAndReceive)
     };
 }
 

--- a/src/NServiceBus.SqlServer.IntegrationTests/When_dispatching_messages.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_dispatching_messages.cs
@@ -99,7 +99,7 @@ namespace NServiceBus.SqlServer.AcceptanceTests.TransportTransaction
 
             await PurgeOutputQueue(addressParser);
 
-            dispatcher = new MessageDispatcher(new TableBasedQueueDispatcher(sqlConnectionFactory), addressParser);
+            dispatcher = new MessageDispatcher(new TableBasedQueueDispatcher(sqlConnectionFactory, null, addressParser), addressParser);
         }
 
         Task PurgeOutputQueue(QueueAddressParser addressParser)
@@ -113,7 +113,7 @@ namespace NServiceBus.SqlServer.AcceptanceTests.TransportTransaction
 
         static Task CreateOutputQueueIfNecessary(QueueAddressParser addressParser)
         {
-            var queueCreator = new QueueCreator(sqlConnectionFactory, addressParser);
+            var queueCreator = new QueueCreator(sqlConnectionFactory, addressParser, new QueueAddress(validAddress + ".Delayed", "dbo"));
             var queueBindings = new QueueBindings();
             queueBindings.BindReceiving(validAddress);
 

--- a/src/NServiceBus.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -71,7 +71,7 @@
 
         static Task CreateQueueIfNotExists(QueueAddressParser addressParser)
         {
-            var queueCreator = new QueueCreator(sqlConnectionFactory, addressParser);
+            var queueCreator = new QueueCreator(sqlConnectionFactory, addressParser, new QueueAddress(QueueTableName + ".Delayed", "dbo"));
             var queueBindings = new QueueBindings();
             queueBindings.BindReceiving(QueueTableName);
 

--- a/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -81,7 +81,7 @@
                 NumberOfReceives ++;
 
                 var readResult = NumberOfReceives <= successfulReceives
-                    ? MessageReadResult.Success(new Message("1", new Dictionary<string, string>(), new byte[0]))
+                    ? MessageReadResult.Success(new Message("1", new Dictionary<string, string>(), new byte[0], null))
                     : MessageReadResult.NoMessage;
 
                 return Task.FromResult(readResult);

--- a/src/NServiceBus.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
@@ -12,7 +12,7 @@ public class ConfigureSqlServerTransportInfrastructure : IConfigureTransportInfr
     public TransportConfigurationResult Configure(SettingsHolder settings, TransportTransactionMode transportTransactionMode)
     {
         this.settings = settings;
-
+        settings.Set("NServiceBus.SharedQueue", settings.EndpointName());
         return new TransportConfigurationResult
         {
             TransportInfrastructure = new SqlServerTransport().Initialize(settings, ConnectionString)

--- a/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
@@ -45,6 +45,7 @@ namespace NServiceBus.Transport.SQLServer
             "mentedException. Will be removed in version 4.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> CallbackReceiverMaxConcurrency(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, int maxConcurrency) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> DefaultSchema(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, string schemaName) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> DelatedMessageStoreSuffix(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, string suffix) { }
         [System.ObsoleteAttribute("Replaced by NServiceBus.Callbacks package. The member currently throws a NotImple" +
             "mentedException. Will be removed in version 4.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> DisableCallbackReceiver(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions) { }
@@ -52,6 +53,7 @@ namespace NServiceBus.Transport.SQLServer
             "eployment. Please refer to documentation for more details. Will be treated as an" +
             " error from version 4.0.0. Will be removed in version 4.0.0.", false)]
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> EnableLegacyMultiInstanceMode(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.Func<string, System.Threading.Tasks.Task<System.Data.SqlClient.SqlConnection>> sqlConnectionFactory) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> MessageDelayResolution(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, int resolutionInSeconds) { }
         [System.ObsoleteAttribute("That config option is no longer supported. The member currently throws a NotImple" +
             "mentedException. Will be removed in version 4.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> PauseAfterReceiveFailure(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.TimeSpan delayTime) { }

--- a/src/NServiceBus.SqlServer.UnitTests/Sending/MessageDispatcherTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/Sending/MessageDispatcherTests.cs
@@ -70,13 +70,13 @@
         {
             public List<string> DispatchedMessageIds = new List<string>();
 
-            public Task DispatchAsNonIsolated(HashSet<MessageWithAddress> operations, TransportTransaction transportTransaction)
+            public Task DispatchAsNonIsolated(UnicastTransportOperation[] operations, TransportTransaction transportTransaction)
             {
                 DispatchedMessageIds.AddRange(operations.Select(x => x.Message.MessageId));
                 return Task.FromResult(0);
             }
 
-            public Task DispatchAsIsolated(HashSet<MessageWithAddress> operations)
+            public Task DispatchAsIsolated(UnicastTransportOperation[] operations)
             {
                 DispatchedMessageIds.AddRange(operations.Select(x => x.Message.MessageId));
                 return Task.FromResult(0);

--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -12,8 +12,5 @@
         public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
 
         public const string SchemaPropertyKey = "Schema";
-
-        public const string DelayedMessageStoreSuffixSettingsKey = "SqlServer.DelayedDelivery.TableSuffix";
-        public const string DelayedDeliveryResolutionSettingsKey = "SqlServer.DelayedDelivery.Resolution";
     }
 }

--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -12,5 +12,8 @@
         public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
 
         public const string SchemaPropertyKey = "Schema";
+
+        public const string DelayedMessageStoreSuffixSettingsKey = "SqlServer.DelayedDelivery.TableSuffix";
+        public const string DelayedDeliveryResolutionSettingsKey = "SqlServer.DelayedDelivery.Resolution";
     }
 }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliverySettings.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.Transport.SQLServer
+{
+    using System;
+    using Configuration.AdvanceExtensibility;
+    using Settings;
+
+    /// <summary>
+    /// Configures native delayed delivery.
+    /// </summary>
+    public class DelayedDeliverySettings : ExposeSettings
+    {
+        internal string TableSuffix { get; private set; }
+        internal int ProcessingResolution { get; private set; }
+
+        internal DelayedDeliverySettings(SettingsHolder settings) 
+            : base(settings)
+        {
+        }
+
+        /// <summary>
+        /// Changes the default suffix of delayed message table (Delayed).
+        /// </summary>
+        /// <param name="suffix"></param>
+        public void MessageStoreTableSuffix(string suffix)
+        {
+            Guard.AgainstNullAndEmpty(nameof(suffix), suffix);
+            TableSuffix = suffix;
+        }
+
+        /// <summary>
+        /// Changes the default resolution of processing the delayed messages (every 5 seconds).
+        /// </summary>
+        /// <param name="resolutionInSeconds"></param>
+        public void MessageStoreProcessingResolution(int resolutionInSeconds)
+        {
+            if (resolutionInSeconds <= 0)
+            {
+                throw new ArgumentException("Processing resolution in seconds has to be a positive number.", nameof(resolutionInSeconds));
+            }
+            ProcessingResolution = resolutionInSeconds;
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageRow.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageRow.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.Transport.SQLServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+
+    class DelayedMessageRow
+    {
+        DelayedMessageRow() { }
+
+        public static DelayedMessageRow From(Dictionary<string, string> headers, byte[] body, DateTime due, string destination)
+        {
+            var row = new DelayedMessageRow();
+
+            row.id = Guid.NewGuid();
+            row.correlationId = TryGetHeaderValue(headers, Headers.CorrelationId, s => s);
+            row.replyToAddress = TryGetHeaderValue(headers, Headers.ReplyToAddress, s => s);
+            row.recoverable = true;
+            row.timeToBeReceived = TryGetHeaderValue(headers, Headers.TimeToBeReceived, s =>
+            {
+                TimeSpan timeToBeReceived;
+                return TimeSpan.TryParse(s, out timeToBeReceived)
+                    ? (int?)timeToBeReceived.TotalMilliseconds
+                    : null;
+            });
+            row.headers = DictionarySerializer.Serialize(headers);
+            row.bodyBytes = body;
+            row.due = due;
+            row.destination = destination;
+            return row;
+        }
+
+
+        public void PrepareSendCommand(SqlCommand command)
+        {
+            AddParameter(command, "Id", SqlDbType.UniqueIdentifier, id);
+            AddParameter(command, "CorrelationId", SqlDbType.VarChar, correlationId);
+            AddParameter(command, "ReplyToAddress", SqlDbType.VarChar, replyToAddress);
+            AddParameter(command, "Recoverable", SqlDbType.Bit, recoverable);
+            AddParameter(command, "TimeToBeReceivedMs", SqlDbType.Int, timeToBeReceived);
+            AddParameter(command, "Headers", SqlDbType.VarChar, headers);
+            AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes);
+            AddParameter(command, "Due", SqlDbType.DateTime, due);
+            AddParameter(command, "Destination", SqlDbType.VarChar, destination);
+        }
+        
+        static T TryGetHeaderValue<T>(Dictionary<string, string> headers, string name, Func<string, T> conversion)
+        {
+            string text;
+            if (!headers.TryGetValue(name, out text))
+            {
+                return default(T);
+            }
+            var value = conversion(text);
+            return value;
+        }
+
+        void AddParameter(SqlCommand command, string name, SqlDbType type, object value)
+        {
+            command.Parameters.Add(name, type).Value = value ?? DBNull.Value;
+        }
+
+        Guid id;
+        string correlationId;
+        string replyToAddress;
+        bool recoverable;
+        int? timeToBeReceived;
+        string headers;
+        byte[] bodyBytes;
+        DateTime due;
+        string destination;
+    }
+}

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport.SQLServer
             }
             catch (Exception ex)
             {
-                ThrowFailedToSendException(ex);
+                throw new Exception("Failed to store a delayed message.", ex);
             }
         }
 
@@ -48,11 +48,6 @@ namespace NServiceBus.Transport.SQLServer
             {
                 return command.ExecuteNonQueryAsync();
             }
-        }
-
-        void ThrowFailedToSendException(Exception ex)
-        {
-            throw new Exception($"Failed to store a delayed message.", ex);
         }
 
         public async Task<int> Purge(SqlConnection connection)

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
@@ -1,0 +1,73 @@
+namespace NServiceBus.Transport.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Threading.Tasks;
+    using Transport;
+
+    class DelayedMessageTable
+    {
+        public DelayedMessageTable(string inputQueue, string delayedMessageTableSuffix, QueueAddressParser addressParser)
+        {
+            using (var sanitizer = new SqlCommandBuilder())
+            {
+                var inputQueueAddress = addressParser.Parse(inputQueue);
+
+                inputQueueTable = sanitizer.QuoteIdentifier(inputQueueAddress.TableName);
+                schema = sanitizer.QuoteIdentifier(inputQueueAddress.SchemaName);
+
+                delayedStoreTable = sanitizer.QuoteIdentifier(inputQueueAddress.TableName + "." + delayedMessageTableSuffix);
+            }
+        }
+
+        public async Task Store(OutgoingMessage message, DateTime dueTime, string destination, SqlConnection connection, SqlTransaction transaction)
+        {
+            var messageRow = DelayedMessageRow.From(message.Headers, message.Body, dueTime, destination);
+
+            var commandText = string.Format(Sql.StoreDelayedMessageText, schema, delayedStoreTable);
+
+            try
+            {
+                using (var command = new SqlCommand(commandText, connection, transaction))
+                {
+                    messageRow.PrepareSendCommand(command);
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                ThrowFailedToSendException(ex);
+            }
+        }
+
+        public Task MoveMaturedMessages(SqlConnection connection, SqlTransaction transaction)
+        {
+            var commandText = string.Format(Sql.MoveMaturedDelayedMessageText, schema, delayedStoreTable, inputQueueTable);
+
+            using (var command = new SqlCommand(commandText, connection, transaction))
+            {
+                return command.ExecuteNonQueryAsync();
+            }
+        }
+
+        void ThrowFailedToSendException(Exception ex)
+        {
+            throw new Exception($"Failed to store a delayed message.", ex);
+        }
+
+        public async Task<int> Purge(SqlConnection connection)
+        {
+            var commandText = string.Format(Sql.PurgeText, schema, delayedStoreTable);
+
+            using (var command = new SqlCommand(commandText, connection))
+            {
+                return await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+        }
+        
+        string delayedStoreTable;
+        string inputQueueTable;
+
+        string schema;
+    }
+}

--- a/src/NServiceBus.SqlServer/DelayedDelivery/MaturedDelayMessageHandler.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/MaturedDelayMessageHandler.cs
@@ -1,0 +1,76 @@
+namespace NServiceBus.Transport.SQLServer
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Logging;
+
+    class MaturedDelayMessageHandler
+    {
+        DelayedMessageTable table;
+        SqlConnectionFactory connectionFactory;
+        TimeSpan resolution;
+        CancellationToken cancellationToken;
+        CancellationTokenSource cancellationTokenSource;
+        Task task;
+
+        public MaturedDelayMessageHandler(DelayedMessageTable table, SqlConnectionFactory connectionFactory, TimeSpan resolution)
+        {
+            this.table = table;
+            this.connectionFactory = connectionFactory;
+            this.resolution = resolution;
+        }
+
+        public void Start()
+        {
+            cancellationTokenSource = new CancellationTokenSource();
+            cancellationToken = cancellationTokenSource.Token;
+
+            task = Task.Run(MoveMaturedDelayedMessages, CancellationToken.None);
+        }
+
+        public async Task Stop()
+        {
+            cancellationTokenSource.Cancel();
+
+            await task.ConfigureAwait(false);
+
+            cancellationTokenSource.Dispose();
+        }
+
+        async Task MoveMaturedDelayedMessages()
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
+                    {
+                        using (var transaction = connection.BeginTransaction())
+                        {
+                            await table.MoveMaturedMessages(connection, transaction).ConfigureAwait(false);
+                            transaction.Commit();
+                        }
+                    }
+                    Logger.DebugFormat("Scheduling next attempt to move matured delayed messages to input queue in {0}", resolution);
+                    await Task.Delay(resolution, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Graceful shutdown
+                }
+                catch (SqlException e) when (cancellationToken.IsCancellationRequested)
+                {
+                    Logger.Debug("Exception thown while performing cancellation", e);
+                }
+                catch (Exception e)
+                {
+                    Logger.Fatal("Exception thown while performing cancellation", e);
+                }
+            }
+        }
+
+        static ILog Logger = LogManager.GetLogger<MaturedDelayMessageHandler>();
+    }
+}

--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacyReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacyReceiveWithTransactionScope.cs
@@ -74,8 +74,11 @@
             {
                 //Forward the message
                 var destinationQueue = QueueFactory(message.Destination);
-                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, null).ConfigureAwait(false);
-                return null;
+                using (var forwardConnection = await connectionFactory.OpenNewConnection(message.Destination).ConfigureAwait(false))
+                {
+                    await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), forwardConnection, null).ConfigureAwait(false);
+                    return null;
+                }
             }
 
             return message;

--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacyReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacyReceiveWithTransactionScope.cs
@@ -69,7 +69,16 @@
                 }
             }
 
-            return receiveResult.Message;
+            var message = receiveResult.Message;
+            if (message.Destination != null)
+            {
+                //Forward the message
+                var destinationQueue = QueueFactory(message.Destination);
+                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, null).ConfigureAwait(false);
+                return null;
+            }
+
+            return message;
         }
 
         TransportTransaction PrepareTransportTransaction(SqlConnection connection)

--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
@@ -86,7 +86,7 @@
             settings.Get<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
 
             return new TransportSendInfrastructure(
-                () => new MessageDispatcher(new LegacyTableBasedQueueDispatcher(connectionFactory), addressParser),
+                () => new MessageDispatcher(new LegacyTableBasedQueueDispatcher(connectionFactory, addressParser), addressParser),
                 () =>
                 {
                     var result = UsingV2ConfigurationChecker.Check();

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Configuration\ConnectionStringsValidator.cs" />
     <Compile Include="Configuration\SettingsKeys.cs" />
     <Compile Include="Configuration\ValidationCheckResult.cs" />
+    <Compile Include="DelayedDelivery\DelayedDeliverySettings.cs" />
     <Compile Include="DelayedDelivery\DelayedMessageRow.cs" />
     <Compile Include="DelayedDelivery\DelayedMessageTable.cs" />
     <Compile Include="DelayedDelivery\MaturedDelayMessageHandler.cs" />

--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -82,6 +82,9 @@
     <Compile Include="Configuration\ConnectionStringsValidator.cs" />
     <Compile Include="Configuration\SettingsKeys.cs" />
     <Compile Include="Configuration\ValidationCheckResult.cs" />
+    <Compile Include="DelayedDelivery\DelayedMessageRow.cs" />
+    <Compile Include="DelayedDelivery\DelayedMessageTable.cs" />
+    <Compile Include="DelayedDelivery\MaturedDelayMessageHandler.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="Legacy\LegacyCallbacks.cs" />

--- a/src/NServiceBus.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Message.cs
@@ -4,15 +4,17 @@
 
     class Message
     {
-        public Message(string transportId, Dictionary<string, string> headers, byte[] body)
+        public Message(string transportId, Dictionary<string, string> headers, byte[] body, string destination)
         {
             TransportId = transportId;
             Body = body;
+            Destination = destination;
             Headers = headers;
         }
 
         public string TransportId { get; }
         public byte[] Body { get; }
-        public Dictionary<string, string> Headers { get; private set; }
+        public string Destination { get; }
+        public Dictionary<string, string> Headers { get; }
     }
 }

--- a/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
@@ -66,6 +66,7 @@
             row.recoverable = await dataReader.GetFieldValueAsync<bool>(3).ConfigureAwait(false);
             row.headers = await GetHeaders(dataReader, 4).ConfigureAwait(false);
             row.bodyBytes = await GetBody(dataReader, 5).ConfigureAwait(false);
+            row.destination = await GetNullableAsync<string>(dataReader, 6).ConfigureAwait(false);
 
             return row;
         }
@@ -85,7 +86,7 @@
 
                 LegacyCallbacks.SubstituteReplyToWithCallbackQueueIfExists(parsedHeaders);
 
-                return MessageReadResult.Success(new Message(id.ToString(), parsedHeaders, bodyBytes));
+                return MessageReadResult.Success(new Message(id.ToString(), parsedHeaders, bodyBytes, destination));
             }
             catch (Exception ex)
             {
@@ -152,6 +153,7 @@
         int? timeToBeReceived;
         string headers;
         byte[] bodyBytes;
+        string destination;
 
         static ILog Logger = LogManager.GetLogger(typeof(MessageRow));
     }

--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -32,7 +32,7 @@
             inputQueue = queueFactory(addressParser.Parse(settings.InputQueue));
             errorQueue = queueFactory(addressParser.Parse(settings.ErrorQueue));
 
-            receiveStrategy.Init(inputQueue, errorQueue, onMessage, onError, criticalError);
+            receiveStrategy.Init(inputQueue, errorQueue, d => queueFactory(addressParser.Parse(d)), onMessage, onError, criticalError);
 
             if (settings.PurgeOnStartup)
             {

--- a/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
@@ -29,8 +29,10 @@ namespace NServiceBus.Transport.SQLServer
                     await CreateQueue(addressParser.Parse(receivingAddress), connection, transaction).ConfigureAwait(false);
                 }
 
-                await CreateDelayedMessageStore(delayedMessageStore, connection, transaction).ConfigureAwait(false);
-
+                if (delayedMessageStore != null)
+                {
+                    await CreateDelayedMessageStore(delayedMessageStore, connection, transaction).ConfigureAwait(false);
+                }
                 transaction.Commit();
             }
         }

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveStrategy.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveStrategy.cs
@@ -9,14 +9,17 @@
     {
         protected TableBasedQueue InputQueue { get; private set; }
         protected TableBasedQueue ErrorQueue { get; private set; }
+        protected Func<string, TableBasedQueue> QueueFactory { get; private set; }
 
         Func<MessageContext, Task> onMessage;
         Func<ErrorContext, Task<ErrorHandleResult>> onError;
 
-        public void Init(TableBasedQueue inputQueue, TableBasedQueue errorQueue, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError)
+        public void Init(TableBasedQueue inputQueue, TableBasedQueue errorQueue, Func<string, TableBasedQueue> queueFactory, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError)
         {
             InputQueue = inputQueue;
             ErrorQueue = errorQueue;
+            QueueFactory = queueFactory;
+
             this.onMessage = onMessage;
             this.onError = onError;
             this.criticalError = criticalError;

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithNativeTransaction.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithNativeTransaction.cs
@@ -57,33 +57,6 @@
             }
         }
 
-        async Task<Message> TryReceive(SqlConnection connection, SqlTransaction transaction, CancellationTokenSource receiveCancellationTokenSource)
-        {
-            var receiveResult = await InputQueue.TryReceive(connection, transaction).ConfigureAwait(false);
-
-            if (receiveResult.IsPoison)
-            {
-                await ErrorQueue.DeadLetter(receiveResult.PoisonMessage, connection, transaction).ConfigureAwait(false);
-                return null;
-            }
-
-            if (!receiveResult.Successful)
-            {
-                receiveCancellationTokenSource.Cancel();
-                return null;
-            }
-
-            var message = receiveResult.Message;
-            if (message.Destination != null)
-            {
-                //Forward the message
-                var destinationQueue = QueueFactory(message.Destination);
-                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, transaction).ConfigureAwait(false);
-                return null;
-            }
-            return message;
-        }
-
         TransportTransaction PrepareTransportTransaction(SqlConnection connection, SqlTransaction transaction)
         {
             var transportTransaction = new TransportTransaction();

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithNativeTransaction.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithNativeTransaction.cs
@@ -73,7 +73,15 @@
                 return null;
             }
 
-            return receiveResult.Message;
+            var message = receiveResult.Message;
+            if (message.Destination != null)
+            {
+                //Forward the message
+                var destinationQueue = QueueFactory(message.Destination);
+                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, transaction).ConfigureAwait(false);
+                return null;
+            }
+            return message;
         }
 
         TransportTransaction PrepareTransportTransaction(SqlConnection connection, SqlTransaction transaction)

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithNoTransaction.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithNoTransaction.cs
@@ -29,10 +29,17 @@ namespace NServiceBus.Transport.SQLServer
                     return;
                 }
 
+                var message = readResult.Message;
+                if (message.Destination != null)
+                {
+                    //Forward the message
+                    var destinationQueue = QueueFactory(message.Destination);
+                    await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, null).ConfigureAwait(false);
+                    return;
+                }
+
                 var transportTransaction = new TransportTransaction();
                 transportTransaction.Set(connection);
-
-                var message = readResult.Message;
 
                 try
                 {

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
@@ -23,7 +23,7 @@
                 using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
                 using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
                 {
-                    message = await TryReceive(connection, receiveCancellationTokenSource).ConfigureAwait(false);
+                    message = await TryReceive(connection, null, receiveCancellationTokenSource).ConfigureAwait(false);
 
                     if (message == null)
                     {
@@ -50,34 +50,6 @@
                 }
                 failureInfoStorage.RecordFailureInfoForMessage(message.TransportId, exception);
             }
-        }
-
-        async Task<Message> TryReceive(SqlConnection connection, CancellationTokenSource receiveCancellationTokenSource)
-        {
-            var receiveResult = await InputQueue.TryReceive(connection, null).ConfigureAwait(false);
-
-            if (receiveResult.IsPoison)
-            {
-                await ErrorQueue.DeadLetter(receiveResult.PoisonMessage, connection, null).ConfigureAwait(false);
-                return null;
-            }
-
-            if (!receiveResult.Successful)
-            {
-                // No result or message expired.
-                receiveCancellationTokenSource.Cancel();
-                return null;
-            }
-
-            var message = receiveResult.Message;
-            if (message.Destination != null)
-            {
-                //Forward the message
-                var destinationQueue = QueueFactory(message.Destination);
-                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, null).ConfigureAwait(false);
-                return null;
-            }
-            return message;
         }
 
         TransportTransaction PrepareTransportTransaction()

--- a/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ReceiveWithTransactionScope.cs
@@ -69,7 +69,15 @@
                 return null;
             }
 
-            return receiveResult.Message;
+            var message = receiveResult.Message;
+            if (message.Destination != null)
+            {
+                //Forward the message
+                var destinationQueue = QueueFactory(message.Destination);
+                await destinationQueue.Send(new OutgoingMessage(message.TransportId, message.Headers, message.Body), connection, null).ConfigureAwait(false);
+                return null;
+            }
+            return message;
         }
 
         TransportTransaction PrepareTransportTransaction()

--- a/src/NServiceBus.SqlServer/Sending/IQueueDispatcher.cs
+++ b/src/NServiceBus.SqlServer/Sending/IQueueDispatcher.cs
@@ -1,12 +1,11 @@
 namespace NServiceBus.Transport.SQLServer
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     interface IQueueDispatcher
     {
-        Task DispatchAsNonIsolated(HashSet<MessageWithAddress> operations, TransportTransaction transportTransaction);
+        Task DispatchAsNonIsolated(UnicastTransportOperation[] operations, TransportTransaction transportTransaction);
 
-        Task DispatchAsIsolated(HashSet<MessageWithAddress> operations);
+        Task DispatchAsIsolated(UnicastTransportOperation[] operations);
     }
 }

--- a/src/NServiceBus.SqlServer/Sending/MessageWithAddress.cs
+++ b/src/NServiceBus.SqlServer/Sending/MessageWithAddress.cs
@@ -1,15 +1,18 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
+    using System;
     using Transport;
 
     class MessageWithAddress
     {
         public QueueAddress Address { get; }
         public OutgoingMessage Message { get; }
+        public DateTime? Due { get; }
 
-        public MessageWithAddress(OutgoingMessage message, QueueAddress address)
+        public MessageWithAddress(OutgoingMessage message, QueueAddress address, DateTime? due)
         {
             Address = address;
+            Due = due;
             Message = message;
         }
     }

--- a/src/NServiceBus.SqlServer/Sending/OperationByMessageIdAndQueueAddressComparer.cs
+++ b/src/NServiceBus.SqlServer/Sending/OperationByMessageIdAndQueueAddressComparer.cs
@@ -2,22 +2,20 @@
 {
     using System.Collections.Generic;
 
-    class OperationByMessageIdAndQueueAddressComparer : IEqualityComparer<MessageWithAddress>
+    class OperationByMessageIdAndQueueAddressComparer : IEqualityComparer<UnicastTransportOperation>
     {
-        public bool Equals(MessageWithAddress x, MessageWithAddress y)
+        public bool Equals(UnicastTransportOperation x, UnicastTransportOperation y)
         {
             return x.Message.MessageId.Equals(y.Message.MessageId)
-                   && x.Address.TableName.Equals(y.Address.TableName)
-                   && x.Address.SchemaName.Equals(y.Address.SchemaName);
+                   && x.Destination.Equals(y.Destination);
         }
 
-        public int GetHashCode(MessageWithAddress obj)
+        public int GetHashCode(UnicastTransportOperation obj)
         {
             unchecked
             {
                 var hashCode = obj.Message.MessageId.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.Address.TableName.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.Address.SchemaName.GetHashCode();
+                hashCode = (hashCode * 397) ^ obj.Destination.GetHashCode();
                 return hashCode;
             }
         }

--- a/src/NServiceBus.SqlServer/Sending/TableBasedQueueDispatcher.cs
+++ b/src/NServiceBus.SqlServer/Sending/TableBasedQueueDispatcher.cs
@@ -99,16 +99,16 @@ namespace NServiceBus.Transport.SQLServer
         {
             foreach (var operation in operations)
             {
-                var due = GetDueTime(operation);
-                if (due.HasValue)
-                {
-                    await delayedMessageTable.Store(operation.Message, due.Value, operation.Destination, connection, transaction).ConfigureAwait(false);
-                }
-                else
+                DateTime? due;
+                if (delayedMessageTable == null || !(due = GetDueTime(operation)).HasValue)
                 {
                     var queueAddress = addressParser.Parse(operation.Destination);
                     var queue = new TableBasedQueue(queueAddress);
                     await queue.Send(operation.Message, connection, transaction).ConfigureAwait(false);
+                }
+                else
+                {
+                    await delayedMessageTable.Store(operation.Message, due.Value, operation.Destination, connection, transaction).ConfigureAwait(false);
                 }
             }
         }

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -29,12 +29,18 @@ namespace NServiceBus.Transport.SQLServer
         /// <summary>
         /// <see cref="TransportInfrastructure.DeliveryConstraints" />
         /// </summary>
-        public override IEnumerable<Type> DeliveryConstraints { get; } = new[]
+        public override IEnumerable<Type> DeliveryConstraints
         {
-            typeof(DiscardIfNotReceivedBefore),
-            typeof(DoNotDeliverBefore),
-            typeof(DelayDeliveryWith)
-        };
+            get
+            {
+                yield return typeof(DiscardIfNotReceivedBefore);
+                if (settings.HasSetting<DelayedDeliverySettings>())
+                {
+                    yield return typeof(DoNotDeliverBefore);
+                    yield return typeof(DelayDeliveryWith);
+                }
+            }
+        }
 
         /// <summary>
         /// <see cref="TransportInfrastructure.TransactionMode" />

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Transport.SQLServer
     using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
+    using DelayedDelivery;
     using Performance.TimeToBeReceived;
     using Routing;
     using Settings;
@@ -21,7 +22,7 @@ namespace NServiceBus.Transport.SQLServer
 
             this.endpointSchemasSettings = settings.GetOrCreate<EndpointSchemasSettings>();
 
-            //HINT: this flag indicates that user need to explicitly turn outbox in configuration.
+            //HINT: this flag indicates that user need to explicitly turn outbox in configusration.
             RequireOutboxConsent = true;
         }
 
@@ -30,7 +31,9 @@ namespace NServiceBus.Transport.SQLServer
         /// </summary>
         public override IEnumerable<Type> DeliveryConstraints { get; } = new[]
         {
-            typeof(DiscardIfNotReceivedBefore)
+            typeof(DiscardIfNotReceivedBefore),
+            typeof(DoNotDeliverBefore),
+            typeof(DelayDeliveryWith)
         };
 
         /// <summary>
@@ -78,9 +81,12 @@ namespace NServiceBus.Transport.SQLServer
 
             Func<QueueAddress, TableBasedQueue> queueFactory = qa => new TableBasedQueue(qa);
 
+            var localAddress = addressParser.Parse(settings.LocalAddress());
+            var delayedTableName = localAddress.TableName + ".Delayed";
+
             return new TransportReceiveInfrastructure(
                 () => new MessagePump(receiveStrategyFactory, queueFactory, queuePurger, expiredMessagesPurger, queuePeeker, addressParser, waitTimeCircuitBreaker),
-                () => new QueueCreator(connectionFactory, addressParser),
+                () => new QueueCreator(connectionFactory, addressParser, new QueueAddress(delayedTableName, localAddress.SchemaName)),
                 () => Task.FromResult(StartupCheckResult.Success));
         }
 
@@ -132,14 +138,28 @@ namespace NServiceBus.Transport.SQLServer
             var connectionFactory = CreateConnectionFactory();
 
             settings.Get<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
+            var delayedMessageTable = new DelayedMessageTable(settings.LocalAddress(), "Delayed", addressParser);
 
             return new TransportSendInfrastructure(
-                () => new MessageDispatcher(new TableBasedQueueDispatcher(connectionFactory), addressParser),
+                () => new MessageDispatcher(new TableBasedQueueDispatcher(connectionFactory, delayedMessageTable,  addressParser), addressParser),
                 () =>
                 {
                     var result = UsingV2ConfigurationChecker.Check();
                     return Task.FromResult(result);
                 });
+        }
+
+        public override Task Start()
+        {
+            var delayedMessageTable = new DelayedMessageTable(settings.LocalAddress(), "Delayed", addressParser);
+            delayedMessageHandler = new MaturedDelayMessageHandler(delayedMessageTable, CreateConnectionFactory(), TimeSpan.FromSeconds(5));
+            delayedMessageHandler.Start();
+            return Task.FromResult(0);
+        }
+
+        public override Task Stop()
+        {
+            return delayedMessageHandler.Stop();
         }
 
         /// <summary>
@@ -200,5 +220,6 @@ namespace NServiceBus.Transport.SQLServer
         string connectionString;
         SettingsHolder settings;
         EndpointSchemasSettings endpointSchemasSettings;
+        MaturedDelayMessageHandler delayedMessageHandler;
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -114,6 +114,29 @@
         }
 
         /// <summary>
+        /// Changes the default suffix of delayed message table (Delayed).
+        /// </summary>
+        public static TransportExtensions<SqlServerTransport> DelatedMessageStoreSuffix(this TransportExtensions<SqlServerTransport> transportExtensions, string suffix)
+        {
+            Guard.AgainstNullAndEmpty(nameof(suffix), suffix);
+            transportExtensions.GetSettings().Set(SettingsKeys.DelayedMessageStoreSuffixSettingsKey, suffix);
+            return transportExtensions;
+        }
+        
+        /// <summary>
+        /// Changes the default resolution of processing the delayed messages (every 5 seconds).
+        /// </summary>
+        public static TransportExtensions<SqlServerTransport> MessageDelayResolution(this TransportExtensions<SqlServerTransport> transportExtensions, int resolutionInSeconds)
+        {
+            if (resolutionInSeconds < 1)
+            {
+                throw new ArgumentException("Resolution (in seconds) has to be a positive number.", nameof(resolutionInSeconds));
+            }
+            transportExtensions.GetSettings().Set(SettingsKeys.DelayedDeliveryResolutionSettingsKey, resolutionInSeconds);
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Enables multi-instance mode.
         /// </summary>
         /// <param name="transportExtensions">The <see cref="TransportExtensions{T}" /> to extend.</param>

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -116,26 +116,13 @@
         /// <summary>
         /// Changes the default suffix of delayed message table (Delayed).
         /// </summary>
-        public static TransportExtensions<SqlServerTransport> DelatedMessageStoreSuffix(this TransportExtensions<SqlServerTransport> transportExtensions, string suffix)
+        public static DelayedDeliverySettings EnableNativeDelayedMessageDelivery(this TransportExtensions<SqlServerTransport> transportExtensions)
         {
-            Guard.AgainstNullAndEmpty(nameof(suffix), suffix);
-            transportExtensions.GetSettings().Set(SettingsKeys.DelayedMessageStoreSuffixSettingsKey, suffix);
-            return transportExtensions;
+            var settings = new DelayedDeliverySettings(transportExtensions.GetSettings());
+            transportExtensions.GetSettings().Set<DelayedDeliverySettings>(settings);
+            return settings;
         }
         
-        /// <summary>
-        /// Changes the default resolution of processing the delayed messages (every 5 seconds).
-        /// </summary>
-        public static TransportExtensions<SqlServerTransport> MessageDelayResolution(this TransportExtensions<SqlServerTransport> transportExtensions, int resolutionInSeconds)
-        {
-            if (resolutionInSeconds < 1)
-            {
-                throw new ArgumentException("Resolution (in seconds) has to be a positive number.", nameof(resolutionInSeconds));
-            }
-            transportExtensions.GetSettings().Set(SettingsKeys.DelayedDeliveryResolutionSettingsKey, resolutionInSeconds);
-            return transportExtensions;
-        }
-
         /// <summary>
         /// Enables multi-instance mode.
         /// </summary>


### PR DESCRIPTION
Native (not requiring persistence) implementation of delayed delivery
 * Uses a table for each endpoint (with `.Delayed` suffix)
 * Delayed messages destined to other endpoint have their ultimate destination in the `Destination` column
 * Delayed messages which mature (their due date has come) are moved periodically (by default every 5 seconds) to the input queue
 * Received messages with non-null `Destination` are immediately forwarded to their ultimate destination instead of processing them in the pipeline

### Comparison to NHibernate peristence based delayed messages

An immediate send cost is 2 (in terms of DB operations). The added cost of a delayed send when using non-native delayed delivery is 8 DB ops. The added cost of a delayed send to self (most common scenario) is 1 DB op (the move operation) and that operation is executed once no matter how many timeouts have matured. Even when considering the most pessimistic scenario when it moves a single message, we reduce the added cost of delayed delivery roughly 8 times.

#### Immediate send

1. Send to destination queue (`INSERT`)
2. Receive at destination queue (`DELETE`)

#### NHibernate

1. Send to satellite (`INSERT`)
2. Receive in satellite (`DETELE`)
3. Store timeout (`INSERT`)
4. Query timeouts (`SELECT`)
5. Send dispatch request (`INSERT`)
6. Receive dispatch request in satellite (`DETELE`)
7. Query timeout (`SELECT`)
8. Dispatch message (`INSERT`)
9. Remove timeout (`DELETE`)
10. Receive at destination queue (`DELETE`)

#### Native (same endpoint)

1. Send to timeout queue (`INSERT`)
2. Move to input queue when matured (`DELETE` + `INSERT`)
3. Receive at destination queue (`DELETE`)

#### Native (different endpoint)

1. Send to timeout queue (`INSERT`)
2. Move to input queue when matured (`DELETE` + `INSERT`)
3. Receive at local input queue (`DELETE`)
4. Forward to destination queue (`INSERT`)
5. Receive at destination queue (`DELETE`)