### PR TITLE
[WIP] Better TTBR query

### DIFF
--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.Transport.SQLServer
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
-        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM {1}.{2} WHERE [RowVersion] IN (SELECT TOP ({0}) [Id] FROM {1}.{2} WITH (NOLOCK) WHERE [Expires] < GETUTCDATE())";
+        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM {1}.{2} WHERE [RowVersion] IN (SELECT TOP ({0}) [RowVersion] FROM {1}.{2} WITH (NOLOCK) WHERE [Expires] < GETUTCDATE())";
 
         internal const string CheckIfExpiresIndexIsPresent = @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('{1}.{2}')";
 

--- a/src/NServiceBus.SqlServer/Queuing/Sql.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Sql.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.Transport.SQLServer
                     EXEC sp_releaseapplock @Resource = '{0}_{1}_lock'
                   END";
 
-        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM {1}.{2} WHERE [Id] IN (SELECT TOP ({0}) [Id] FROM {1}.{2} WITH (UPDLOCK, READPAST, ROWLOCK) WHERE [Expires] < GETUTCDATE() ORDER BY [RowVersion])";
+        internal const string PurgeBatchOfExpiredMessagesText = "DELETE FROM {1}.{2} WHERE [RowVersion] IN (SELECT TOP ({0}) [Id] FROM {1}.{2} WITH (NOLOCK) WHERE [Expires] < GETUTCDATE())";
 
         internal const string CheckIfExpiresIndexIsPresent = @"SELECT COUNT(*) FROM [sys].[indexes] WHERE [name] = '{0}' AND [object_id] = OBJECT_ID('{1}.{2}')";
 


### PR DESCRIPTION
## Changes
This is a proposal of a change to the query used to purging expired messages from input queue. The changes were made only to the PurgeBatchOfExpiredMessages query and include:
 * Inner select:
  * Running in `READ UNCOMMITTED` (`NOLOCK` hint) and without `ORDER BY` on `RowVersion` column
  * Returns `RowVersion` instead of `Id`
 * Outer delete
  * `WHERE` clause includes only `RowVersion`

## Why
Direct reason for changes was #308. Which reported a deadlock situation that was caused by `receiveMessage` and `purgeBatchOrExpiredMessages` queries running at the same time. Here is the diagram that was included in the original issue.
![image](https://cloud.githubusercontent.com/assets/152998/19114770/b4284d6c-8b0f-11e6-95fc-95c3d2477532.png)
Process on the left is a `readMessage` operation that tries to delete row from input queue. To do that it needs exclusive IX lock both on clustered index `on RowVersion` column and non-clustered index `Expired` column. As seen on the diagram it already has IX on the second and waits for the first one.
Process on the right is a `purgeBatchOrExpiredMessages` operation that runs in `READ COMMITTED` isolation level and holds shared U lock on non-clustered index (caused by `WHERE [Expires] < GETUTCDATE()` in inner select) and tries to get another shared U lock on clustered index to perform `ORDER by RowVersion`. This causes a deadlock. The root cause of deadlock is the fact that locks are taken in reverse order by `readMessage` and `purgeBatchOrExpiredMessages`.

The changes proposed in this PR do not resolve the problem completely but I believe make the likelihood of deadlock smaller. Here is why: 
 * Running inner select in `purgeBatchOrExpiredMessages` prevents it from holding any locks 
 * Returning `RowVersion` from inner select which is clustered index encourages using clustered index and holding locks only on rows which are to be deleted. Screenshot below shows query plans for new query (first one) and the old query (lower one). "1" shows the inner select part and "2" loop that uses results of inner select to find rows in clustered index by `RowVersion`

![image](https://cloud.githubusercontent.com/assets/1092707/19232547/af809b96-8ee0-11e6-90ad-0a8b928ef7d9.png)

This change puts us in situation when deadlocking between two queries could happen when they they try to delete the same row. That being said this should be a border case scenario because both queries use disjoint predicates in where statements. When it comes to scaled-out instance the queries for reads and purging will most of the times use the same execution plans which will prevent deadlocks as well. 

/cc: @Particular/sqlserver-transport-maintainers @ramonsmits @Scooletz 