### PR TITLE
Don’t validate “Min Pool Size” (0 is fine) and give better warning

### DIFF
--- a/src/NServiceBus.SqlServer.UnitTests/ConnectionPoolValidatorTests.cs
+++ b/src/NServiceBus.SqlServer.UnitTests/ConnectionPoolValidatorTests.cs
@@ -31,14 +31,6 @@
         }
 
         [Test]
-        public void Is_not_validated_when_only_max_pool_size_is_specified()
-        {
-            var result = ConnectionPoolValidator.Validate("Initial Catalog = xxx; Max Pool Size = 200");
-
-            Assert.IsFalse(result.IsValid);
-        }
-
-        [Test]
         public void Is_not_validated_when_pooling_is_enabled_and_no_min_and_max_is_set()
         {
             var result = ConnectionPoolValidator.Validate("Initial Catalog = xxx; Pooling = true");

--- a/src/NServiceBus.SqlServer/Configuration/ConnectionPoolValidator.cs
+++ b/src/NServiceBus.SqlServer/Configuration/ConnectionPoolValidator.cs
@@ -15,7 +15,7 @@
                 return ValidationCheckResult.Valid();
             }
 
-            if (!keys.ContainsKey("Max Pool Size") || !keys.ContainsKey("Min Pool Size"))
+            if (!keys.ContainsKey("Max Pool Size"))
             {
                 return ValidationCheckResult.Invalid(ConnectionPoolSizeNotSet);
             }
@@ -24,7 +24,7 @@
         }
 
         const string ConnectionPoolSizeNotSet = 
-            "Minimum and Maximum connection pooling values are not " +
-            "configured on the provided connection string.";
+            "Maximum connection pooling value (Max Pool Size=N) is not " +
+            "configured on the provided connection string. The default value (100) will be used.";
     }
 }


### PR DESCRIPTION
Since there's no reason 0 can't be the minimum, there's no reason to bother the user if this setting isn't defined in the connection string.

@Particular/sqlserver-transport-maintainers please review.