### PR TITLE
Use GetOrCreate for endpoint instances

### DIFF
--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
@@ -83,7 +83,7 @@
         {
             var connectionFactory = CreateLegacyConnectionFactory();
 
-            settings.Get<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
+            settings.GetOrCreate<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
 
             return new TransportSendInfrastructure(
                 () => new MessageDispatcher(new LegacyTableBasedQueueDispatcher(connectionFactory), addressParser),

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -116,7 +116,7 @@ namespace NServiceBus.Transport.SQLServer
         {
             var connectionFactory = CreateConnectionFactory();
 
-            settings.Get<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
+            settings.GetOrCreate<EndpointInstances>().AddOrReplaceInstances("SqlServer", endpointSchemasSettings.ToEndpointInstances());
 
             return new TransportSendInfrastructure(
                 () => new MessageDispatcher(new TableBasedQueueDispatcher(connectionFactory), addressParser),


### PR DESCRIPTION
This removes the blocker for using SQL Server transport in raw mode (dispatcher + pump) as the previous code (Get) assumed the routing feature is enabled.

This does not change the behavior of normal endpoints.