### PR TITLE
Usewildcardsfortests

### DIFF
--- a/src/CompatibilityTests/Facade_1.2/Facade_1.2.csproj
+++ b/src/CompatibilityTests/Facade_1.2/Facade_1.2.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.0" />
-    <PackageReference Include="NServiceBus" Version="4.4.8" />
-    <PackageReference Include="NServiceBus.Interfaces" Version="4.4.8" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="1.2.5" />
+    <PackageReference Include="log4net" Version="2.*" />
+    <PackageReference Include="NServiceBus" Version="4.*" />
+    <PackageReference Include="NServiceBus.Interfaces" Version="4.*" />
+    <PackageReference Include="NServiceBus.SqlServer" Version="1.2.*" />
     <ProjectReference Include="..\..\NServiceBus.SqlServer.CompatibilityTests.Common\NServiceBus.SqlServer.CompatibilityTests.Common.csproj" />
     <Reference Include="System.Configuration" />
   </ItemGroup>

--- a/src/CompatibilityTests/Facade_2.2/Facade_2.2.csproj
+++ b/src/CompatibilityTests/Facade_2.2/Facade_2.2.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.0" />
-    <PackageReference Include="NServiceBus" Version="5.2.14" />
-    <PackageReference Include="NServiceBus.Log4Net" Version="1.0.0" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="2.2.4" />
+    <PackageReference Include="log4net" Version="2.*" />
+    <PackageReference Include="NServiceBus" Version="5.*" />
+    <PackageReference Include="NServiceBus.Log4Net" Version="1.*" />
+    <PackageReference Include="NServiceBus.SqlServer" Version="2.2.*" />
     <ProjectReference Include="..\..\NServiceBus.SqlServer.CompatibilityTests.Common\NServiceBus.SqlServer.CompatibilityTests.Common.csproj" />
     <Reference Include="System.Configuration" />
   </ItemGroup>

--- a/src/CompatibilityTests/Facade_3.0/Facade_3.0.csproj
+++ b/src/CompatibilityTests/Facade_3.0/Facade_3.0.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.3.1" />
-    <PackageReference Include="NServiceBus.Callbacks" Version="2.0.0" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="3.0.2" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="2.*" />
+    <PackageReference Include="NServiceBus.SqlServer" Version="3.0.*" />
     <ProjectReference Include="..\..\NServiceBus.SqlServer.CompatibilityTests.Common\NServiceBus.SqlServer.CompatibilityTests.Common.csproj" />
     <Reference Include="System.Configuration" />
   </ItemGroup>

--- a/src/CompatibilityTests/Facade_3.1/Facade_3.1.csproj
+++ b/src/CompatibilityTests/Facade_3.1/Facade_3.1.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.3.1" />
-    <PackageReference Include="NServiceBus.Callbacks" Version="2.0.0" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="2.*" />
     <ProjectReference Include="..\..\NServiceBus.SqlServer.CompatibilityTests.Common\NServiceBus.SqlServer.CompatibilityTests.Common.csproj" />
     <ProjectReference Include="..\..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
     <Reference Include="System.Configuration" />

--- a/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NServiceBus.SqlServer.AcceptanceTests.csproj
@@ -4,10 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.3.4" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.4" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.4" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.*" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
     <ProjectReference Include="..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.SqlServer.CompatibilityTests.Common/NServiceBus.SqlServer.CompatibilityTests.Common.csproj
+++ b/src/NServiceBus.SqlServer.CompatibilityTests.Common/NServiceBus.SqlServer.CompatibilityTests.Common.csproj
@@ -4,6 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.SqlServer.CompatibilityTests/NServiceBus.SqlServer.CompatibilityTests.csproj
+++ b/src/NServiceBus.SqlServer.CompatibilityTests/NServiceBus.SqlServer.CompatibilityTests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.1.1" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
     <ProjectReference Include="..\NServiceBus.SqlServer.CompatibilityTests.Common\NServiceBus.SqlServer.CompatibilityTests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.SqlServer.IntegrationTests/NServiceBus.SqlServer.IntegrationTests.csproj
+++ b/src/NServiceBus.SqlServer.IntegrationTests/NServiceBus.SqlServer.IntegrationTests.csproj
@@ -6,11 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.1.1" />
-    <PackageReference Include="Iesi.Collections" Version="4.0.1.4000" />
-    <PackageReference Include="NHibernate" Version="4.0.4.4000" />
-    <PackageReference Include="NServiceBus.NHibernate" Version="7.0.0" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.NHibernate" Version="7.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
     <ProjectReference Include="..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
     <Reference Include="System.Transactions" />
   </ItemGroup>

--- a/src/NServiceBus.SqlServer.TransportTests/NServiceBus.SqlServer.TransportTests.csproj
+++ b/src/NServiceBus.SqlServer.TransportTests/NServiceBus.SqlServer.TransportTests.csproj
@@ -4,9 +4,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.3.4" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.4" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
     <ProjectReference Include="..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -8,15 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="6.1.1" />
-    <PackageReference Include="Iesi.Collections" Version="4.0.1.4000" />
-    <PackageReference Include="NHibernate" Version="4.0.4.4000" />
-    <PackageReference Include="NServiceBus.NHibernate" Version="7.0.0" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="ApprovalTests" Version="3.0.13" />
-    <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
-    <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
-    <PackageReference Include="ApiApprover" Version="3.0.1" />
+    <PackageReference Include="NServiceBus" Version="6.*" />
+    <PackageReference Include="NServiceBus.NHibernate" Version="7.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="ApprovalTests" Version="3.*" />
+    <PackageReference Include="ApprovalUtilities" Version="3.*" />
+    <PackageReference Include="Mono.Cecil" Version="0.9.*" />
+    <PackageReference Include="ApiApprover" Version="3.*" />
     <ProjectReference Include="..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />


### PR DESCRIPTION
allow tests to auto update and run on the correct version without needing to do a nuget update