### PR TITLE
Expired message are only purged on startup and only if explicitly enabled

### DIFF
--- a/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -33,7 +33,7 @@
                 m => new ProcessWithNoTransaction(sqlConnectionFactory),
                 qa => qa == "input" ? (TableBasedQueue)inputQueue : new TableBasedQueue(parser.Parse(qa).QualifiedTableName, qa),
                 new QueuePurger(sqlConnectionFactory),
-                new ExpiredMessagesPurger(_ => sqlConnectionFactory.OpenNewConnection(), TimeSpan.MaxValue, 0),
+                new ExpiredMessagesPurger(_ => sqlConnectionFactory.OpenNewConnection(), 0, false),
                 new QueuePeeker(sqlConnectionFactory, new QueuePeekerOptions()),
                 new SchemaInspector(_ => sqlConnectionFactory.OpenNewConnection()),
                 TimeSpan.MaxValue);
@@ -89,7 +89,7 @@
                 NumberOfReceives ++;
 
                 var readResult = NumberOfReceives <= successfulReceives
-                    ? MessageReadResult.Success(new Message("1", new Dictionary<string, string>(), new byte[0]))
+                    ? MessageReadResult.Success(new Message("1", new Dictionary<string, string>(), new byte[0], false))
                     : MessageReadResult.NoMessage;
 
                 return Task.FromResult(readResult);

--- a/src/NServiceBus.SqlServer.IntegrationTests/When_using_ttbr.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_using_ttbr.cs
@@ -40,9 +40,8 @@ namespace NServiceBus.SqlServer.AcceptanceTests.TransportTransaction
                     transaction.Commit();
                 }
 
-                var expired = await queue.PurgeBatchOfExpiredMessages(connection, 100).ConfigureAwait(false);
-
-                Assert.AreEqual(0, expired);
+                var message = await queue.TryReceive(connection, null).ConfigureAwait(false);
+                Assert.IsFalse(message.Message.Expired);
             }
         }
 
@@ -74,9 +73,8 @@ namespace NServiceBus.SqlServer.AcceptanceTests.TransportTransaction
                     transaction.Commit();
                 }
 
-                var expired = await queue.PurgeBatchOfExpiredMessages(connection, 100).ConfigureAwait(false);
-
-                Assert.AreEqual(0, expired);
+                var message = await queue.TryReceive(connection, null).ConfigureAwait(false);
+                Assert.IsFalse(message.Message.Expired);
             }
         }
 
@@ -109,9 +107,8 @@ namespace NServiceBus.SqlServer.AcceptanceTests.TransportTransaction
                     transaction.Commit();
                 }
 
-                var expired = await queue.PurgeBatchOfExpiredMessages(connection, 100).ConfigureAwait(false);
-
-                Assert.AreEqual(1, expired);
+                var message = await queue.TryReceive(connection, null).ConfigureAwait(false);
+                Assert.IsTrue(message.Message.Expired);
             }
         }
 

--- a/src/NServiceBus.SqlServer.TestHarness/NServiceBus.SqlServer.TestHarness.csproj
+++ b/src/NServiceBus.SqlServer.TestHarness/NServiceBus.SqlServer.TestHarness.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.SqlServer\NServiceBus.SqlServer.csproj" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <!--<PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta0004" />-->
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.SqlServer.TestHarness/Program.cs
+++ b/src/NServiceBus.SqlServer.TestHarness/Program.cs
@@ -1,0 +1,196 @@
+﻿using System;
+
+namespace NServiceBus.SqlServer.TestHarness
+{
+    using System.Collections.Concurrent;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class Program
+    {
+        public const int MessageCount = 20000;
+
+        static void Main(string[] args)
+        {
+            Start().GetAwaiter().GetResult();
+        }
+
+        static async Task Start()
+        {
+            var receiverConfig = CreateReceiverConfig();
+            receiverConfig.PurgeOnStartup(true);
+
+            //Create queue or purge it if present
+            var receiver = await Endpoint.Start(receiverConfig);
+            await receiver.Stop();
+
+            var senderConfig = new EndpointConfiguration("TestHarness.Sender");
+            senderConfig.SendOnly();
+            senderConfig.UsePersistence<InMemoryPersistence>();
+            var transport = senderConfig.UseTransport<SqlServerTransport>();
+            transport.ConnectionString(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True");
+            var routing = transport.Routing();
+            routing.RouteToEndpoint(typeof(TestMessage), "TestHarness.Receiver");
+            routing.RouteToEndpoint(typeof(DoneMessage), "TestHarness.Receiver");
+            routing.RouteToEndpoint(typeof(InitMessage), "TestHarness.Receiver");
+
+            var sender = await Endpoint.Start(senderConfig);
+
+            await sender.Send(new InitMessage());
+
+            var concurrencyLimiter = new SemaphoreSlim(8);
+            var runningTasks = new ConcurrentDictionary<Task, Task>();
+            for (var i = 0; i < MessageCount; i++)
+            {
+                concurrencyLimiter.Wait();
+
+                var receiveTask = Send(concurrencyLimiter, sender);
+                runningTasks.TryAdd(receiveTask, receiveTask);
+
+#pragma warning disable 4014
+                receiveTask.ContinueWith((t, state) =>
+#pragma warning restore 4014
+                {
+                    var receiveTasks = (ConcurrentDictionary<Task, Task>)state;
+                    receiveTasks.TryRemove(t, out Task _);
+                }, runningTasks, TaskContinuationOptions.ExecuteSynchronously);
+            }
+
+            var allTasks = runningTasks.Values.ToArray();
+            await Task.WhenAll(allTasks);
+            await sender.Send(new DoneMessage());
+            await sender.Stop();
+
+            await Task.Delay(2000);
+
+            Console.WriteLine($"Sending {MessageCount} messages complete");
+
+            receiverConfig = CreateReceiverConfig();
+            var tcs = new TaskCompletionSource<bool>();
+            var stats = new ReceiveStats(tcs);
+            receiverConfig.RegisterComponents(c => c.RegisterSingleton(stats));
+            receiver = await Endpoint.Start(receiverConfig);
+
+            await tcs.Task;
+            await receiver.Stop();
+
+            Console.WriteLine("Press <enter> to exit");
+            Console.ReadLine();
+        }
+
+        static async Task Send(SemaphoreSlim concurrencyLimiter, IEndpointInstance sender)
+        {
+            try
+            {
+                await sender.Send(new TestMessage());
+
+            }
+            finally
+            {
+                concurrencyLimiter.Release();
+            }
+        }
+
+        static EndpointConfiguration CreateReceiverConfig()
+        {
+            var receiverConfig = new EndpointConfiguration("TestHarness.Receiver");
+            receiverConfig.SendFailedMessagesTo("error");
+            receiverConfig.UseTransport<SqlServerTransport>().ConnectionString(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True");
+            receiverConfig.UsePersistence<InMemoryPersistence>();
+            receiverConfig.EnableInstallers();
+            return receiverConfig;
+        }
+    }
+
+    class ReceiveStats
+    {
+        Stopwatch watch;
+        TaskCompletionSource<bool> tcs;
+        int testMessagesReceived;
+
+        public ReceiveStats(TaskCompletionSource<bool> tcs)
+        {
+            this.tcs = tcs;
+        }
+
+        public void Test()
+        {
+            Interlocked.Increment(ref testMessagesReceived);
+        }
+
+        public void Init()
+        {
+            watch = Stopwatch.StartNew();
+        }
+
+        public void Done()
+        {
+            watch.Stop();
+            Console.WriteLine($"Received {testMessagesReceived} out of {Program.MessageCount} messages in {watch.ElapsedMilliseconds} ms.");
+            tcs.SetResult(true);
+        }
+    }
+
+    [TimeToBeReceived("00:00:01")]
+    class TestMessage : IMessage
+    {
+    }
+
+    class TestMessageHandler : IHandleMessages<TestMessage>
+    {
+        ReceiveStats receiveStats;
+
+        public TestMessageHandler(ReceiveStats receiveStats)
+        {
+            this.receiveStats = receiveStats;
+        }
+
+        public Task Handle(TestMessage message, IMessageHandlerContext context)
+        {
+            receiveStats.Test();
+            return Task.CompletedTask;
+        }
+    }
+
+    class InitMessage : IMessage
+    {
+    }
+
+    class InitMessageHandler : IHandleMessages<InitMessage>
+    {
+        ReceiveStats receiveStats;
+
+        public InitMessageHandler(ReceiveStats receiveStats)
+        {
+            this.receiveStats = receiveStats;
+        }
+
+        public Task Handle(InitMessage message, IMessageHandlerContext context)
+        {
+            receiveStats.Init();
+            return Task.CompletedTask;
+        }
+    }
+
+    class DoneMessage : IMessage
+    {
+    }
+
+    class DoneMessageHandler : IHandleMessages<DoneMessage>
+    {
+        ReceiveStats receiveStats;
+
+        public DoneMessageHandler(ReceiveStats receiveStats)
+        {
+            this.receiveStats = receiveStats;
+        }
+
+        public Task Handle(DoneMessage message, IMessageHandlerContext context)
+        {
+            receiveStats.Done();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
@@ -41,6 +41,7 @@ namespace NServiceBus.Transport.SQLServer
             "g addressing instead. The member currently throws a NotImplementedException. Wil" +
             "l be removed in version 5.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> EnableLegacyMultiInstanceMode(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.Func<string, System.Threading.Tasks.Task<System.Data.SqlClient.SqlConnection>> sqlConnectionFactory) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> PurgeExpiredMessagesOnStartup(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.Nullable<int> purgeBatchSize) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.TimeSpan waitTime) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> UseCatalogForEndpoint(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, string endpointName, string catalog) { }

--- a/src/NServiceBus.SqlServer.sln
+++ b/src/NServiceBus.SqlServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.SqlServer", "NServiceBus.SqlServer\NServiceBus.SqlServer.csproj", "{FA1193BF-325C-4201-BB78-484032E09809}"
 EndProject
@@ -35,6 +35,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Facade_3_1", "CompatibilityTests\Facade_3.1\Facade_3_1.csproj", "{66D10F43-3859-4F55-B8A8-60E32AD6B813}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.SqlServer.IntegrationTests.Sql", "NServiceBus.SqlServer.IntegrationTests.Sql\NServiceBus.SqlServer.IntegrationTests.Sql.csproj", "{15430E85-0954-445B-9F1D-4E5D321AE9BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.SqlServer.TestHarness", "NServiceBus.SqlServer.TestHarness\NServiceBus.SqlServer.TestHarness.csproj", "{373C5E59-6994-4120-A569-8EAA8F4A8CC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -90,6 +92,10 @@ Global
 		{15430E85-0954-445B-9F1D-4E5D321AE9BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15430E85-0954-445B-9F1D-4E5D321AE9BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15430E85-0954-445B-9F1D-4E5D321AE9BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{373C5E59-6994-4120-A569-8EAA8F4A8CC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{373C5E59-6994-4120-A569-8EAA8F4A8CC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{373C5E59-6994-4120-A569-8EAA8F4A8CC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{373C5E59-6994-4120-A569-8EAA8F4A8CC7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -9,8 +9,8 @@
         public const string LegacyMultiInstanceConnectionFactory = "SqlServer.LegacyMultiInstanceConnectionFactory";
         public const string MultiCatalogEnabled = "SqlServer.MultiCatalogEnabled";
 
-        public const string PurgeTaskDelayTimeSpanKey = "SqlServer.PurgeTaskDelayTimeSpan";
         public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
+        public const string PurgeEnableKey = "SqlServer.PurgeExpiredOnStartup";
 
         public const string SchemaPropertyKey = "Schema";
         public const string CatalogPropertyKey = "Catalog";

--- a/src/NServiceBus.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.SqlServer/Queuing/Message.cs
@@ -4,13 +4,14 @@
 
     class Message
     {
-        public Message(string transportId, Dictionary<string, string> headers, byte[] body)
+        public Message(string transportId, Dictionary<string, string> headers, byte[] body, bool expired)
         {
             TransportId = transportId;
             Body = body;
+            Expired = expired;
             Headers = headers;
         }
-
+        public bool Expired { get; }
         public string TransportId { get; }
         public byte[] Body { get; }
         public Dictionary<string, string> Headers { get; }

--- a/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
@@ -48,22 +48,15 @@
         static async Task<MessageRow> ReadRow(SqlDataReader dataReader)
         {
             //HINT: we are assuming that dataReader is sequential. Order or reads is important !
-            var id = await dataReader.GetFieldValueAsync<Guid>(0).ConfigureAwait(false);
-            var correlationId = await GetNullableAsync<string>(dataReader, 1).ConfigureAwait(false);
-            var replyTo = await GetNullableAsync<string>(dataReader, 2).ConfigureAwait(false);
-            var recoverable = await dataReader.GetFieldValueAsync<bool>(3).ConfigureAwait(false);
-            var expired = await dataReader.GetFieldValueAsync<int>(4).ConfigureAwait(false) == 1;
-            var headers = await GetHeaders(dataReader, 5).ConfigureAwait(false);
-            var body = await GetBody(dataReader, 6).ConfigureAwait(false);
             return new MessageRow
             {
-                id = id,
-                correlationId = correlationId,
-                replyToAddress = replyTo,
-                recoverable = recoverable,
-                expired = expired,
-                headers = headers,
-                bodyBytes = body
+                id = await dataReader.GetFieldValueAsync<Guid>(0).ConfigureAwait(false),
+                correlationId = await GetNullableAsync<string>(dataReader, 1).ConfigureAwait(false),
+                replyToAddress = await GetNullableAsync<string>(dataReader, 2).ConfigureAwait(false),
+                recoverable = await dataReader.GetFieldValueAsync<bool>(3).ConfigureAwait(false),
+                expired = await dataReader.GetFieldValueAsync<int>(4).ConfigureAwait(false) == 1,
+                headers = await GetHeaders(dataReader, 5).ConfigureAwait(false),
+                bodyBytes = await GetBody(dataReader, 6).ConfigureAwait(false)
             };
         }
 

--- a/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
@@ -48,14 +48,22 @@
         static async Task<MessageRow> ReadRow(SqlDataReader dataReader)
         {
             //HINT: we are assuming that dataReader is sequential. Order or reads is important !
+            var id = await dataReader.GetFieldValueAsync<Guid>(0).ConfigureAwait(false);
+            var correlationId = await GetNullableAsync<string>(dataReader, 1).ConfigureAwait(false);
+            var replyTo = await GetNullableAsync<string>(dataReader, 2).ConfigureAwait(false);
+            var recoverable = await dataReader.GetFieldValueAsync<bool>(3).ConfigureAwait(false);
+            var expired = await dataReader.GetFieldValueAsync<int>(4).ConfigureAwait(false) == 1;
+            var headers = await GetHeaders(dataReader, 5).ConfigureAwait(false);
+            var body = await GetBody(dataReader, 6).ConfigureAwait(false);
             return new MessageRow
             {
-                id = await dataReader.GetFieldValueAsync<Guid>(0).ConfigureAwait(false),
-                correlationId = await GetNullableAsync<string>(dataReader, 1).ConfigureAwait(false),
-                replyToAddress = await GetNullableAsync<string>(dataReader, 2).ConfigureAwait(false),
-                recoverable = await dataReader.GetFieldValueAsync<bool>(3).ConfigureAwait(false),
-                headers = await GetHeaders(dataReader, 4).ConfigureAwait(false),
-                bodyBytes = await GetBody(dataReader, 5).ConfigureAwait(false)
+                id = id,
+                correlationId = correlationId,
+                replyToAddress = replyTo,
+                recoverable = recoverable,
+                expired = expired,
+                headers = headers,
+                bodyBytes = body
             };
         }
 
@@ -73,7 +81,7 @@
                 }
 
                 LegacyCallbacks.SubstituteReplyToWithCallbackQueueIfExists(parsedHeaders);
-                return MessageReadResult.Success(new Message(id.ToString(), parsedHeaders, bodyBytes));
+                return MessageReadResult.Success(new Message(id.ToString(), parsedHeaders, bodyBytes, expired));
             }
             catch (Exception ex)
             {
@@ -134,6 +142,7 @@
         string correlationId;
         string replyToAddress;
         bool recoverable;
+        bool expired;
         int? timeToBeReceived;
         string headers;
         byte[] bodyBytes;

--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -59,7 +59,6 @@
             cancellationToken = cancellationTokenSource.Token;
 
             messagePumpTask = Task.Run(ProcessMessages, CancellationToken.None);
-            purgeTask = Task.Run(PurgeExpiredMessages, CancellationToken.None);
         }
 
         public async Task Stop()
@@ -71,8 +70,7 @@
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutDurationInSeconds));
             var allTasks = runningReceiveTasks.Values.Concat(new[]
             {
-                messagePumpTask,
-                purgeTask
+                messagePumpTask
             });
             var finishedTask = await Task.WhenAny(Task.WhenAll(allTasks), timeoutTask).ConfigureAwait(false);
 
@@ -89,6 +87,7 @@
 
         async Task ProcessMessages()
         {
+            await PurgeExpiredMessages().ConfigureAwait(false);
             while (!cancellationToken.IsCancellationRequested)
             {
                 try
@@ -144,7 +143,7 @@
 
                     receiveTask.ContinueWith((t, state) =>
                     {
-                        var receiveTasks = (ConcurrentDictionary<Task, Task>) state;
+                        var receiveTasks = (ConcurrentDictionary<Task, Task>)state;
                         receiveTasks.TryRemove(t, out Task _);
                     }, runningReceiveTasks, TaskContinuationOptions.ExecuteSynchronously)
                     .Ignore();
@@ -184,32 +183,22 @@
 
         async Task PurgeExpiredMessages()
         {
-            while (!cancellationToken.IsCancellationRequested)
+            try
             {
-                try
-                {
-                    await expiredMessagesPurger.Purge(inputQueue, cancellationToken).ConfigureAwait(false);
-
-                    Logger.DebugFormat("Scheduling next expired message purge task for queue {0} in {1}", inputQueue, expiredMessagesPurger.PurgeTaskDelay);
-                    await Task.Delay(expiredMessagesPurger.PurgeTaskDelay, cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Graceful shutdown
-                }
-                catch (SqlException e) when (e.Number == 1205)
-                {
-                    //Purge has been victim of a lock resolution
-                    Logger.Warn("Purger has been selected as a lock victim.", e);
-                }
-                catch (SqlException e) when (cancellationToken.IsCancellationRequested)
-                {
-                    Logger.Debug("Exception thown while performing cancellation", e);
-                }
-                catch (Exception e)
-                {
-                    Logger.WarnFormat("Purging expired messages from table {0} failed with exception: {1}.", inputQueue, e);
-                }
+                await expiredMessagesPurger.Purge(inputQueue, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Graceful shutdown
+            }
+            catch (SqlException e) when (e.Number == 1205)
+            {
+                //Purge has been victim of a lock resolution
+                Logger.Warn("Purger has been selected as a lock victim.", e);
+            }
+            catch (SqlException e) when (cancellationToken.IsCancellationRequested)
+            {
+                Logger.Debug("Exception thown while performing cancellation", e);
             }
         }
 
@@ -229,7 +218,6 @@
         RepeatedFailuresOverTimeCircuitBreaker peekCircuitBreaker;
         RepeatedFailuresOverTimeCircuitBreaker receiveCircuitBreaker;
         Task messagePumpTask;
-        Task purgeTask;
         ReceiveStrategy receiveStrategy;
 
         static ILog Logger = LogManager.GetLogger<MessagePump>();

--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -47,6 +47,8 @@
                 }
             }
 
+            await PurgeExpiredMessages().ConfigureAwait(false);
+
             await schemaInspector.PerformInspection(inputQueue).ConfigureAwait(false);
         }
 
@@ -87,7 +89,6 @@
 
         async Task ProcessMessages()
         {
-            await PurgeExpiredMessages().ConfigureAwait(false);
             while (!cancellationToken.IsCancellationRequested)
             {
                 try

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -136,10 +136,10 @@ namespace NServiceBus.Transport.SQLServer
 
         ExpiredMessagesPurger CreateExpiredMessagesPurger(SqlConnectionFactory connectionFactory)
         {
-            var purgeTaskDelay = settings.HasSetting(SettingsKeys.PurgeTaskDelayTimeSpanKey) ? settings.Get<TimeSpan?>(SettingsKeys.PurgeTaskDelayTimeSpanKey) : null;
             var purgeBatchSize = settings.HasSetting(SettingsKeys.PurgeBatchSizeKey) ? settings.Get<int?>(SettingsKeys.PurgeBatchSizeKey) : null;
+            var enable = settings.GetOrDefault<bool>(SettingsKeys.PurgeEnableKey);
 
-            return new ExpiredMessagesPurger(_ => connectionFactory.OpenNewConnection(), purgeTaskDelay, purgeBatchSize);
+            return new ExpiredMessagesPurger(_ => connectionFactory.OpenNewConnection(), purgeBatchSize, enable);
         }
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -185,6 +185,21 @@
         }
 
         /// <summary>
+        /// Instructs the transport to purge all expired messages from the input queue before starting the processing.
+        /// </summary>
+        /// <param name="transportExtensions">The <see cref="TransportExtensions{T}" /> to extend.</param>
+        /// <param name="purgeBatchSize">Maximum number of messages in each delete batch.</param>
+        public static TransportExtensions<SqlServerTransport> PurgeExpiredMessagesOnStartup(this TransportExtensions<SqlServerTransport> transportExtensions, int? purgeBatchSize)
+        {
+            transportExtensions.GetSettings().Set(SettingsKeys.PurgeEnableKey, true);
+            if (purgeBatchSize.HasValue)
+            {
+                transportExtensions.GetSettings().Set(SettingsKeys.PurgeBatchSizeKey, purgeBatchSize);
+            }
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Enables multi-instance mode.
         /// </summary>
         /// <param name="transportExtensions">The <see cref="TransportExtensions{T}" /> to extend.</param>


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.SqlServer/issues/396

I decided to require explicit enabling of the purge-on-startup feature because in a scale-out environment purging on startup by default can cause problems.