### PR TITLE
Explicitly set size for Body parameter when inserting in queue

### DIFF
--- a/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.SqlServer/Queuing/MessageRow.cs
@@ -42,7 +42,7 @@
             AddParameter(command, "Recoverable", SqlDbType.Bit, recoverable);
             AddParameter(command, "TimeToBeReceivedMs", SqlDbType.Int, timeToBeReceived);
             AddParameter(command, "Headers", SqlDbType.NVarChar, headers);
-            AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes);
+            AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes, -1);
         }
 
         static async Task<MessageRow> ReadRow(SqlDataReader dataReader)
@@ -129,6 +129,11 @@
         void AddParameter(SqlCommand command, string name, SqlDbType type, object value)
         {
             command.Parameters.Add(name, type).Value = value ?? DBNull.Value;
+        }
+
+        void AddParameter(SqlCommand command, string name, SqlDbType type, object value, int size)
+        {
+            command.Parameters.Add(name, type, size).Value = value ?? DBNull.Value;
         }
 
         Guid id;


### PR DESCRIPTION
After moving our production environment to NServiceBus 6 with SQL transport we noticed a very high number of execution plans for the insert queries on the various queue tables. Further analysis revealed that this was caused by the Body parameter being passed as a VARBINARY(<size of byte array>), which means that for every different size of message SQL Server will generate a new execution plan.

By setting the Size property on the parameter to -1, the parameter is passed to SQL Server as a VARBINARY(MAX). That means that every execution of the query can use the same execution plan.