### PR TITLE
Added option to turn off connection string validation

### DIFF
--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -14,5 +14,7 @@
 
         public const string SchemaPropertyKey = "Schema";
         public const string CatalogPropertyKey = "Catalog";
+
+        public const string DisableConnectionStringValidation = "SqlServer.DisableConnectionStringValidation";
     }
 }

--- a/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/Legacy/MultiInstance/LegacySqlServerTransportInfrastructure.cs
@@ -107,6 +107,11 @@
                 () => new LegacyMessageDispatcher(addressTranslator, connectionFactory), 
                 () =>
                 {
+                    if (settings.HasSetting(SettingsKeys.DisableConnectionStringValidation))
+                    {
+                        return Task.FromResult(StartupCheckResult.Success);
+                    }
+
                     var result = UsingV2ConfigurationChecker.Check();
                     return Task.FromResult(result);
                 });

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -167,7 +167,10 @@ namespace NServiceBus.Transport.SQLServer
                 },
                 () =>
                 {
-                    var result = UsingV2ConfigurationChecker.Check();
+                    var result = settings.HasSetting(SettingsKeys.DisableConnectionStringValidation) 
+                        ? StartupCheckResult.Success 
+                        : UsingV2ConfigurationChecker.Check();
+                    
                     if (result.Succeeded && delayedDeliverySettings != null)
                     {
                         result = DelayedDeliveryInfrastructure.CheckForInvalidSettings(settings);


### PR DESCRIPTION
## Overview
This PR enables turning off connection string validation that checks if connection strings are not using unsupported parameters. 

This is needed to enable schema configuration in SC.Monitoring in the way consistent with current version of SC.