### PR TITLE
add missing sql connection to TransportTransaction

### DIFF
--- a/src/NServiceBus.SqlServer/Receiving/ProcessWithTransactionScope.cs
+++ b/src/NServiceBus.SqlServer/Receiving/ProcessWithTransactionScope.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
     using System;
+    using System.Data.SqlClient;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
@@ -35,7 +36,7 @@
 
                     connection.Close();
 
-                    if (!await TryProcess(message, PrepareTransportTransaction()).ConfigureAwait(false))
+                    if (!await TryProcess(message, PrepareTransportTransaction(connection)).ConfigureAwait(false))
                     {
                         return;
                     }
@@ -55,12 +56,13 @@
             }
         }
 
-        TransportTransaction PrepareTransportTransaction()
+        TransportTransaction PrepareTransportTransaction(SqlConnection connection)
         {
             var transportTransaction = new TransportTransaction();
 
             //those resources are meant to be used by anyone except message dispatcher e.g. persister
             transportTransaction.Set(Transaction.Current);
+            transportTransaction.Set(connection);
 
             return transportTransaction;
         }


### PR DESCRIPTION
The current connection is exposed in these two places

  * https://github.com/Particular/NServiceBus.SqlServer/blob/release-4.0/src/NServiceBus.SqlServer/Receiving/ProcessWithNativeTransaction.cs#L66
 * https://github.com/Particular/NServiceBus.SqlServer/blob/release-4.0/src/NServiceBus.SqlServer/Receiving/ProcessWithNoTransaction.cs#L32

but not here https://github.com/Particular/NServiceBus.SqlServer/blob/release-4.0/src/NServiceBus.SqlServer/Receiving/ProcessWithTransactionScope.cs#L63

This adds the connection to the 3rd case as well

