### PR TITLE
Ignoring flaky test

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.6/Retries/When_sending_to_slr.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.6/Retries/When_sending_to_slr.cs
@@ -30,6 +30,7 @@
         }
         
         [Test]
+        [Ignore("There is a race condition between endpoint starting and IWantToRunWhenBusStartsAndStops in NSB 5.2.")]
         public void Should_raise_FinishedMessageProcessing_event()
         {
             var context = new Context();


### PR DESCRIPTION
In the NSB 5.2 there is a race condition where IWantToRunWhenBusStartsAndStops https://github.com/Particular/NServiceBus/blob/support-5.2/src/NServiceBus.Core/Unicast/UnicastBus.cs#L680. 

This causes the ignored test to fail in cases when messages is processed before the IWantToRunWhenBusStartsAndStops is initialized.