### PR TITLE
Don't flood logs

### DIFF
--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -130,7 +130,10 @@
                 // We cannot dispose this token source because of potential race conditions of concurrent receives
                 var loopCancellationTokenSource = new CancellationTokenSource();
 
-                for (var i = 0; i < messageCount; i++)
+                // If the receive circuit breaker is triggered start only one message processing task at a time.
+                var maximumConcurrentReceives = receiveCircuitBreaker.Triggered ? 1 : messageCount; 
+
+                for (var i = 0; i < maximumConcurrentReceives; i++)
                 {
                     if (loopCancellationTokenSource.Token.IsCancellationRequested)
                     {

--- a/src/NServiceBus.SqlServer/Receiving/RepeatedFailuresOvertimeCurcuitBreaker.cs
+++ b/src/NServiceBus.SqlServer/Receiving/RepeatedFailuresOvertimeCurcuitBreaker.cs
@@ -16,7 +16,7 @@
             timer = new Timer(CircuitBreakerTriggered);
         }
 
-        public bool Triggered { get; private set; }
+        public bool Triggered => triggered;
 
         public void Dispose()
         {
@@ -33,7 +33,7 @@
             }
 
             timer.Change(Timeout.Infinite, Timeout.Infinite);
-            Triggered = false;
+            triggered = false;
             Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
         }
 
@@ -56,7 +56,7 @@
         {
             if (Interlocked.Read(ref failureCount) > 0)
             {
-                Triggered = true;
+                triggered = true;
                 Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
                 triggerAction(lastException);
             }
@@ -69,6 +69,7 @@
         Action<Exception> triggerAction;
         long failureCount;
         Exception lastException;
+        volatile bool triggered;
 
         static TimeSpan NoPeriodicTriggering = TimeSpan.FromMilliseconds(-1);
         static ILog Logger = LogManager.GetLogger<RepeatedFailuresOverTimeCircuitBreaker>();


### PR DESCRIPTION
I decided to use two values instead of a classic exponential back-off because:
 * We don't ever want to wait for less than 1 second
 * We don't ever want to wait for more than 10 seconds so that when the DB is back online we can quickly resume processing

Based on these bounds with exponential back-off we would only permit `c` values of 1,2 and 3 (2^3=8) which gives little benefit for the added complexity.

In case when `peek` works fine but `receive` fails (i.e. lack of `DELETE` permissions) the receive circuit breaker is going to be triggered. To prevent concurrently hammering the database the message pump has been modified to run only a single receive task at a time if the receive CB is triggered.