### PR TITLE
Maintenance release 1

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_passing_custom_transaction_via_sendoptions.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_passing_custom_transaction_via_sendoptions.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Transport.SQLServer;
+
+    public class When_passing_custom_transaction_via_sendoptions : NServiceBusAcceptanceTest
+    {
+        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+
+        [Test]
+        public async Task Should_be_used_by_send_operations()
+        {
+            var context = await Scenario.Define<MyContext>()
+                .WithEndpoint<AnEndpoint>(c => c.When(async bus =>
+                {
+                    using (var connection = new SqlConnection(ConnectionString))
+                    {
+                        connection.Open();
+
+                        using (var rolledbackTransaction = connection.BeginTransaction())
+                        {
+                            var options = new SendOptions();
+
+                            options.UseCustomSqlConnectionAndTransaction(connection, rolledbackTransaction);
+
+                            await bus.Send(new FromRolledbackTransaction(), options);
+
+                            rolledbackTransaction.Rollback();
+                        }
+
+                        using (var commitedTransaction = connection.BeginTransaction())
+                        {
+                            var options = new SendOptions();
+
+                            options.UseCustomSqlConnectionAndTransaction(connection, commitedTransaction);
+
+                            await bus.Send(new FromCommitedTransaction(), options);
+
+                            commitedTransaction.Commit();
+                        }
+                    }
+                    
+                }))
+                .Done(c => c.ReceivedFromCommitedTransaction)
+                .Run(TimeSpan.FromMinutes(1));
+
+            Assert.IsFalse(context.ReceivedFromRolledbackTransaction);
+        }
+
+        class FromCommitedTransaction : IMessage
+        {
+        }
+
+        class FromRolledbackTransaction : IMessage
+        {
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public bool ReceivedFromCommitedTransaction { get; set; }
+            public bool ReceivedFromRolledbackTransaction { get; set; }
+        }
+
+        class AnEndpoint : EndpointConfigurationBuilder
+        {
+            public AnEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.LimitMessageProcessingConcurrencyTo(1);
+
+                    var routing = c.ConfigureTransport().Routing();
+                    var anEndpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(AnEndpoint));
+
+                    routing.RouteToEndpoint(typeof(FromCommitedTransaction), anEndpointName);
+                    routing.RouteToEndpoint(typeof(FromRolledbackTransaction), anEndpointName);
+                });
+            }
+
+            class ReplyHandler : IHandleMessages<FromRolledbackTransaction>, 
+                IHandleMessages<FromCommitedTransaction>
+            {
+                public MyContext Context { get; set; }
+
+                public Task Handle(FromRolledbackTransaction message, IMessageHandlerContext context)
+                {
+                    Context.ReceivedFromRolledbackTransaction = true;
+
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(FromCommitedTransaction message, IMessageHandlerContext context)
+                {
+                    Context.ReceivedFromCommitedTransaction = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+       
+    }
+}

--- a/src/NServiceBus.SqlServer.AcceptanceTests/When_using_computed_message_body_column.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/When_using_computed_message_body_column.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.SqlServer.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Transport.SQLServer;
+
+    public class When_using_computed_message_body_column : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Simple_send_is_received()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.SendLocal(new MyMessage())))
+                .Done(c => c.WasCalled)
+                .Run();
+
+            Assert.IsTrue(context.WasCalled);
+      }
+        class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var transportConfig = config.UseTransport<SqlServerTransport>();
+                    transportConfig.CreateMessageBodyComputedColumn();
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
@@ -22,6 +22,10 @@ namespace NServiceBus.Transport.SQLServer
         public void ProcessingInterval(System.TimeSpan interval) { }
         public void TableSuffix(string suffix) { }
     }
+    public class static SendOptionsExtensions
+    {
+        public static void UseCustomSqlConnectionAndTransaction(this NServiceBus.SendOptions options, System.Data.SqlClient.SqlConnection connection, System.Data.SqlClient.SqlTransaction transaction) { }
+    }
     [System.ObsoleteAttribute("Not for public use.")]
     public class static SqlConstants
     {

--- a/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.SqlServer.UnitTests/APIApprovals.Approve.approved.txt
@@ -25,6 +25,7 @@ namespace NServiceBus.Transport.SQLServer
     [System.ObsoleteAttribute("Not for public use.")]
     public class static SqlConstants
     {
+        public static readonly string AddMessageBodyStringColumn;
         public static readonly string CheckHeadersColumnType;
         public static readonly string CheckIfExpiresIndexIsPresent;
         public const string CreateDelayedMessageStoreText = @"
@@ -46,7 +47,6 @@ BEGIN
 END
 CREATE TABLE {0} (
     Headers nvarchar(max) NOT NULL,
-    BodyString as cast(Body AS nvarchar(max)),
     Body varbinary(max),
     Due datetime NOT NULL,
     RowVersion bigint IDENTITY(1,1) NOT NULL
@@ -65,6 +65,7 @@ EXEC sp_releaseapplock @Resource = '{0}_lock'";
     }
     public class static SqlServerTransportSettingsExtensions
     {
+        public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> CreateMessageBodyComputedColumn(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> DefaultSchema(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions, string schemaName) { }
         [System.ObsoleteAttribute("Multi-instance mode has been deprecated. Use Transport Bridge and/or multi-catalo" +
             "g addressing instead. The member currently throws a NotImplementedException. Wil" +

--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -12,6 +12,8 @@
         public const string PurgeBatchSizeKey = "SqlServer.PurgeBatchSize";
         public const string PurgeEnableKey = "SqlServer.PurgeExpiredOnStartup";
 
+        public const string CreateMessageBodyComputedColumn = "SqlServer.CreateMessageBodyComputedColumn";
+
         public const string SchemaPropertyKey = "Schema";
         public const string CatalogPropertyKey = "Catalog";
     }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryQueueCreator.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryQueueCreator.cs
@@ -6,11 +6,12 @@ namespace NServiceBus.Transport.SQLServer
 
     class DelayedDeliveryQueueCreator : ICreateQueues
     {
-        public DelayedDeliveryQueueCreator(SqlConnectionFactory connectionFactory, ICreateQueues queueCreator, CanonicalQueueAddress delayedMessageTable)
+        public DelayedDeliveryQueueCreator(SqlConnectionFactory connectionFactory, ICreateQueues queueCreator, CanonicalQueueAddress delayedMessageTable, bool createMessageBodyComputedColumn = false)
         {
             this.connectionFactory = connectionFactory;
             this.queueCreator = queueCreator;
             this.delayedMessageTable = delayedMessageTable;
+            this.createMessageBodyComputedColumn = createMessageBodyComputedColumn;
         }
 
         public async Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -19,12 +20,13 @@ namespace NServiceBus.Transport.SQLServer
             using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
             using (var transaction = connection.BeginTransaction())
             {
-                await CreateDelayedMessageQueue(delayedMessageTable, connection, transaction).ConfigureAwait(false);
+                await CreateDelayedMessageQueue(delayedMessageTable, connection, transaction, createMessageBodyComputedColumn).ConfigureAwait(false);
+
                 transaction.Commit();
             }
         }
 
-        static async Task CreateDelayedMessageQueue(CanonicalQueueAddress canonicalQueueAddress, SqlConnection connection, SqlTransaction transaction)
+        static async Task CreateDelayedMessageQueue(CanonicalQueueAddress canonicalQueueAddress, SqlConnection connection, SqlTransaction transaction, bool createMessageBodyComputedColumn)
         {
 #pragma warning disable 618
             var sql = string.Format(SqlConstants.CreateDelayedMessageStoreText, canonicalQueueAddress.QualifiedTableName, canonicalQueueAddress.QuotedCatalogName);
@@ -36,10 +38,26 @@ namespace NServiceBus.Transport.SQLServer
             {
                 await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
+            if (createMessageBodyComputedColumn)
+            {
+#pragma warning disable 618
+                var bodyStringSql = string.Format(SqlConstants.AddMessageBodyStringColumn, canonicalQueueAddress.QualifiedTableName, canonicalQueueAddress.QuotedCatalogName);
+#pragma warning restore 618
+                using (var command = new SqlCommand(bodyStringSql, connection, transaction)
+                {
+                    CommandType = CommandType.Text
+                })
+                {
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+
+            }
         }
+
 
         SqlConnectionFactory connectionFactory;
         ICreateQueues queueCreator;
         CanonicalQueueAddress delayedMessageTable;
+        bool createMessageBodyComputedColumn;
     }
 }

--- a/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
@@ -8,10 +8,11 @@ namespace NServiceBus.Transport.SQLServer
 
     class QueueCreator : ICreateQueues
     {
-        public QueueCreator(SqlConnectionFactory connectionFactory, QueueAddressTranslator addressTranslator)
+        public QueueCreator(SqlConnectionFactory connectionFactory, QueueAddressTranslator addressTranslator, bool createMessageBodyColumn = false)
         {
             this.connectionFactory = connectionFactory;
             this.addressTranslator = addressTranslator;
+            this.createMessageBodyColumn = createMessageBodyColumn;
         }
 
         public async Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -21,18 +22,18 @@ namespace NServiceBus.Transport.SQLServer
             {
                 foreach (var receivingAddress in queueBindings.ReceivingAddresses)
                 {
-                    await CreateQueue(addressTranslator.Parse(receivingAddress), connection, transaction).ConfigureAwait(false);
+                    await CreateQueue(addressTranslator.Parse(receivingAddress), connection, transaction, createMessageBodyColumn).ConfigureAwait(false);
                 }
 
                 foreach (var sendingAddress in queueBindings.SendingAddresses)
                 {
-                    await CreateQueue(addressTranslator.Parse(sendingAddress), connection, transaction).ConfigureAwait(false);
+                    await CreateQueue(addressTranslator.Parse(sendingAddress), connection, transaction, createMessageBodyColumn).ConfigureAwait(false);
                 }
                 transaction.Commit();
             }
         }
 
-        static async Task CreateQueue(CanonicalQueueAddress canonicalQueueAddress, SqlConnection connection, SqlTransaction transaction)
+        static async Task CreateQueue(CanonicalQueueAddress canonicalQueueAddress, SqlConnection connection, SqlTransaction transaction, bool createMessageBodyColumn)
         {
             var sql = string.Format(SqlConstants.CreateQueueText, canonicalQueueAddress.QualifiedTableName, canonicalQueueAddress.QuotedCatalogName);
             using (var command = new SqlCommand(sql, connection, transaction)
@@ -42,10 +43,23 @@ namespace NServiceBus.Transport.SQLServer
             {
                 await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
+
+            if (createMessageBodyColumn)
+            {
+                var bodyStringSql = string.Format(SqlConstants.AddMessageBodyStringColumn, canonicalQueueAddress.QualifiedTableName, canonicalQueueAddress.QuotedCatalogName);
+                using (var command = new SqlCommand(bodyStringSql, connection, transaction)
+                {
+                    CommandType = CommandType.Text
+                })
+                {
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+            }
         }
 
         SqlConnectionFactory connectionFactory;
         QueueAddressTranslator addressTranslator;
+        bool createMessageBodyColumn;
     }
 }
 #pragma warning restore 618

--- a/src/NServiceBus.SqlServer/SendOptionsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SendOptionsExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Transport.SQLServer
+{
+    using System.Data.SqlClient;
+    using Extensibility;
+
+    /// <summary>
+    /// Adds transport specific settings to SendOptions
+    /// </summary>
+    public static class SendOptionsExtensions
+    {
+        /// <summary>
+        /// Enables providing SqlConnection and SqlTransaction instances that will be used by send operations. The same connection and transaction
+        /// can be used in more than one send operation.
+        /// </summary>
+        /// <param name="options">The <see cref="SendOptions" /> to extend.</param>
+        /// <param name="connection">Open SqlConnection instance to be used by send operations.</param>
+        /// <param name="transaction">SqlTransaction instance that will be used by any operations perfromed by the transport.</param>
+        public static void UseCustomSqlConnectionAndTransaction(this SendOptions options, SqlConnection connection, SqlTransaction transaction)
+        {
+            var transportTransaction = new TransportTransaction();
+            transportTransaction.Set(connection);
+            transportTransaction.Set(transaction);
+
+            options.GetExtensions().Set(transportTransaction);
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -23,6 +23,12 @@ namespace NServiceBus.Transport.SQLServer
             schemaAndCatalogSettings = settings.GetOrCreate<EndpointSchemaAndCatalogSettings>();
             delayedDeliverySettings = settings.GetOrDefault<DelayedDeliverySettings>();
             var timeoutManagerFeatureDisabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Disabled;
+            
+            diagnostics.Add("NServiceBus.Transport.SqlServer.TimeoutManager", new
+            {
+                FeatureEnabled = !timeoutManagerFeatureDisabled
+            });
+            
             if (delayedDeliverySettings != null && timeoutManagerFeatureDisabled)
             {
                 delayedDeliverySettings.DisableTimeoutManagerCompatibility();
@@ -53,10 +59,22 @@ namespace NServiceBus.Transport.SQLServer
                 scopeOptions = new SqlScopeOptions();
             }
 
+            settings.TryGet(out TransportTransactionMode transactionMode);
+            diagnostics.Add("NServiceBus.Transport.SqlServer.Transactions", new
+            {
+                TransactionMode = transactionMode,
+                scopeOptions.TransactionOptions.IsolationLevel,
+                scopeOptions.TransactionOptions.Timeout
+            });
+
             if (!settings.TryGet(SettingsKeys.TimeToWaitBeforeTriggering, out TimeSpan waitTimeCircuitBreaker))
             {
                 waitTimeCircuitBreaker = TimeSpan.FromSeconds(30);
             }
+            diagnostics.Add("NServiceBus.Transport.SqlServer.CircuitBreaker", new
+            {
+                TimeToWaitBeforeTriggering = waitTimeCircuitBreaker
+            });
 
             if (!settings.TryGet(out QueuePeekerOptions queuePeekerOptions))
             {
@@ -139,6 +157,12 @@ namespace NServiceBus.Transport.SQLServer
         {
             var purgeBatchSize = settings.HasSetting(SettingsKeys.PurgeBatchSizeKey) ? settings.Get<int?>(SettingsKeys.PurgeBatchSizeKey) : null;
             var enable = settings.GetOrDefault<bool>(SettingsKeys.PurgeEnableKey);
+
+            diagnostics.Add("NServiceBus.Transport.SqlServer.ExpiredMessagesPurger", new
+            {
+                FeatureEnabled = enable,
+                BatchSize = purgeBatchSize
+            });
 
             return new ExpiredMessagesPurger(_ => connectionFactory.OpenNewConnection(), purgeBatchSize, enable);
         }
@@ -237,10 +261,29 @@ namespace NServiceBus.Transport.SQLServer
 
         public override Task Start()
         {
+            foreach (var diagnosticSection in diagnostics)
+            {
+                settings.AddStartupDiagnosticsSection(diagnosticSection.Key, diagnosticSection.Value);
+            }
+
             if (delayedDeliverySettings == null)
             {
+                settings.AddStartupDiagnosticsSection("NServiceBus.Transport.SqlServer.DelayedDelivery", new
+                {
+                    Native = false
+                });
                 return Task.FromResult(0);
             }
+
+            settings.AddStartupDiagnosticsSection("NServiceBus.Transport.SqlServer.DelayedDelivery", new
+            {
+                Native = true,
+                delayedDeliverySettings.Suffix,
+                delayedDeliverySettings.Interval,
+                BatchSize = delayedDeliverySettings.MatureBatchSize,
+                TimoutManager = delayedDeliverySettings.TimeoutManagerDisabled ? "disabled" : "enabled"
+            });
+
             var delayedMessageTable = CreateDelayedMessageTable();
             delayedMessageHandler = new DelayedMessageHandler(delayedMessageTable, CreateConnectionFactory(), delayedDeliverySettings.Interval, delayedDeliverySettings.MatureBatchSize);
             delayedMessageHandler.Start();
@@ -289,5 +332,6 @@ namespace NServiceBus.Transport.SQLServer
         EndpointSchemaAndCatalogSettings schemaAndCatalogSettings;
         DelayedMessageHandler delayedMessageHandler;
         DelayedDeliverySettings delayedDeliverySettings;
+        Dictionary<string, object> diagnostics = new Dictionary<string, object>();
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -63,6 +63,8 @@ namespace NServiceBus.Transport.SQLServer
                 queuePeekerOptions = new QueuePeekerOptions();
             }
 
+            var createMessageBodyComputedColumn = settings.GetOrDefault<bool>(SettingsKeys.CreateMessageBodyComputedColumn);
+
             var connectionFactory = CreateConnectionFactory();
 
             Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory =
@@ -93,12 +95,12 @@ namespace NServiceBus.Transport.SQLServer
                 },
                 () =>
                 {
-                    var creator = new QueueCreator(connectionFactory, addressTranslator);
+                    var creator = new QueueCreator(connectionFactory, addressTranslator, createMessageBodyComputedColumn);
                     if (delayedDeliverySettings == null)
                     {
                         return creator;
                     }
-                    return new DelayedDeliveryQueueCreator(connectionFactory, creator, delayedMessageStore);
+                    return new DelayedDeliveryQueueCreator(connectionFactory, creator, delayedMessageStore, createMessageBodyComputedColumn);
                 },
                 () => CheckForAmbientTransactionEnlistmentSupport(connectionFactory, scopeOptions.TransactionOptions));
         }

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -200,6 +200,17 @@
         }
 
         /// <summary>
+        /// Instructs the transport to create a computed column for inspecting message body contents.
+        /// </summary>
+        /// <param name="transportExtensions">The <see cref="TransportExtensions{T}" /> to extend.</param>
+        public static TransportExtensions<SqlServerTransport> CreateMessageBodyComputedColumn(this TransportExtensions<SqlServerTransport> transportExtensions)
+        {
+            transportExtensions.GetSettings().Set(SettingsKeys.CreateMessageBodyComputedColumn, true);
+
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Enables multi-instance mode.
         /// </summary>
         /// <param name="transportExtensions">The <see cref="TransportExtensions{T}" /> to extend.</param>

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -6,6 +6,7 @@
     using System.Transactions;
     using Configuration.AdvancedExtensibility;
     using Features;
+    using Logging;
 
     /// <summary>
     /// Adds extra configuration for the Sql Server transport.
@@ -151,6 +152,11 @@
         {
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
 
+            if (isolationLevel != IsolationLevel.ReadCommitted && isolationLevel != IsolationLevel.RepeatableRead)
+            {
+                Logger.Warn("TransactionScope should be only used with either the ReadCommited or the RepeatableRead isolation level.");
+            }
+
             transportExtensions.GetSettings().Set<SqlScopeOptions>(new SqlScopeOptions(timeout, isolationLevel));
             return transportExtensions;
         }
@@ -223,5 +229,7 @@
         {
             throw new NotImplementedException();
         }
+
+        static ILog Logger = LogManager.GetLogger<SqlServerTransport>();
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportSettingsExtensions.cs
@@ -80,6 +80,7 @@
             var settings = transportExtensions.GetSettings();
 
             settings.Set(SettingsKeys.MultiCatalogEnabled, true);
+
             var schemasConfiguration = settings.GetOrCreate<EndpointSchemaAndCatalogSettings>();
 
             schemasConfiguration.SpecifyCatalog(endpointName, catalog);
@@ -103,6 +104,7 @@
             var settings = transportExtensions.GetSettings();
 
             settings.Set(SettingsKeys.MultiCatalogEnabled, true);
+
             var schemasConfiguration = settings.GetOrCreate<QueueSchemaAndCatalogSettings>();
 
             schemasConfiguration.SpecifyCatalog(queueName, catalog);
@@ -123,6 +125,7 @@
             Guard.AgainstNegativeAndZero(nameof(waitTime), waitTime);
 
             transportExtensions.GetSettings().Set(SettingsKeys.TimeToWaitBeforeTriggering, waitTime);
+            
             return transportExtensions;
         }
 
@@ -158,6 +161,7 @@
             }
 
             transportExtensions.GetSettings().Set<SqlScopeOptions>(new SqlScopeOptions(timeout, isolationLevel));
+
             return transportExtensions;
         }
 

--- a/src/Scripts/Create-Databases.sql
+++ b/src/Scripts/Create-Databases.sql
@@ -23,7 +23,6 @@ CREATE TABLE error (
     Recoverable bit NOT NULL,
     Expires datetime,
     Headers nvarchar(max) NOT NULL,
-    BodyString as cast(Body as nvarchar(max)),
     Body varbinary(max),
     RowVersion bigint IDENTITY(1,1) NOT NULL
 );

--- a/src/Scripts/Reset-Database.sql
+++ b/src/Scripts/Reset-Database.sql
@@ -144,7 +144,6 @@ CREATE TABLE error (
     Recoverable bit NOT NULL,
     Expires datetime,
     Headers nvarchar(max) NOT NULL,
-    BodyString as cast(Body AS nvarchar(max)),
     Body varbinary(max),
     RowVersion bigint IDENTITY(1,1) NOT NULL
 );


### PR DESCRIPTION
- Remove isolation level settings on the SqlTransport https://github.com/Particular/NServiceBus.SqlServer/issues/312
- Add startup diagnostics info https://github.com/Particular/NServiceBus.SqlServer/issues/404 
- Add an opt-in computed column for viewing message body https://github.com/Particular/NServiceBus.SqlServer/issues/445
- Allow passing an existing connection/transaction via send options https://github.com/Particular/NServiceBus.SqlServer/issues/444
- Ensure this fix has been included https://github.com/Particular/PlatformDevelopment/issues/1983

Docs https://github.com/Particular/docs.particular.net/pull/3861