### PR TITLE
WIP: Body contains utf8 byte array

### DIFF
--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -140,7 +140,7 @@ BEGIN
 END
 
 ALTER TABLE {0} 
-ADD BodyString as cast(Body as nvarchar(max));
+ADD BodyString as cast(Body as varchar(max));
 
 EXEC sp_releaseapplock @Resource = '{0}_lock'";
 


### PR DESCRIPTION
## Description

The SqlServer transport allows [BodyString](https://docs.particular.net/transports/sql/design?version=sqltransport_7#structure-bodystring) setting. When turned on, the queue tables are created with an additional column that stores the message body in text format. This can be useful when browsing the input queue.

Currently, message body text is JSON/XML serialized and stored as utf8 byte array rather than 16 bits characters. This causes invalid display and makes the column less useful.

This PR is the first step we still need to:

 - [ ] Make sure the new schema works with older endpoints
 - [ ] Check if this change is backward compatible and potentially make the first step (make the new column schema nvarchar by default and change that in the next major)
