### PR TITLE
Fix `master` builds

### DIFF
--- a/src/CompatibilityTests/Facade_3.0/Handler.cs
+++ b/src/CompatibilityTests/Facade_3.0/Handler.cs
@@ -16,9 +16,7 @@ public class Handler : IHandleMessages<TestCommand>, IHandleMessages<TestRequest
 
     public Task Handle(TestRequest message, IMessageHandlerContext context)
     {
-        context.Reply(new TestResponse { ResponseId = message.RequestId });
-
-        return Task.FromResult(0);
+        return context.Reply(new TestResponse { ResponseId = message.RequestId });
     }
 
     public Task Handle(TestResponse message, IMessageHandlerContext context)

--- a/src/CompatibilityTests/Facade_3.1/Handler.cs
+++ b/src/CompatibilityTests/Facade_3.1/Handler.cs
@@ -16,9 +16,7 @@ public class Handler : IHandleMessages<TestCommand>, IHandleMessages<TestRequest
 
     public Task Handle(TestRequest message, IMessageHandlerContext context)
     {
-        context.Reply(new TestResponse { ResponseId = message.RequestId });
-
-        return Task.FromResult(0);
+        return context.Reply(new TestResponse { ResponseId = message.RequestId });
     }
 
     public Task Handle(TestResponse message, IMessageHandlerContext context)

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="3.*" NoWarn="NU1701" />
-    <PackageReference Include="ApprovalUtilities" Version="3.*" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalTests" Version="3.0.15" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.15" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />

--- a/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.SqlServer.UnitTests/NServiceBus.SqlServer.UnitTests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="3.0.15" NoWarn="NU1701" />
-    <PackageReference Include="ApprovalUtilities" Version="3.0.15" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />


### PR DESCRIPTION
## Overview
There have been changes to `ApprovalTests` and `ApprovalUtilities` in versions 3.0.16. They are no longer targeting `.NETFramework 4.5` but `.NETFramework 4.6.1` and/or `.NETStandard 2.0`. That causes the build on master to fail for unit test which targets `.NETFramework 4.5`. 

In addition, this PR includes adding missing awaits in compatibility tests.