### PR TITLE
Use TimeSpan instead of DateTime

### DIFF
--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeiveryTableBasedQueueFactory.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeiveryTableBasedQueueFactory.cs
@@ -70,7 +70,7 @@ namespace NServiceBus.Transport.SQLServer
             {
                 return new DispatchBehavior
                 {
-                    DueAfter = dueAfter,
+                    DueAfter = dueAfter < TimeSpan.Zero ? TimeSpan.Zero : dueAfter,
                     Defer = true,
                     Destination = destination
                 };

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageRow.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageRow.cs
@@ -9,7 +9,7 @@
     {
         DelayedMessageRow() { }
 
-        public static DelayedMessageRow From(Dictionary<string, string> headers, byte[] body, DateTime due, string destination)
+        public static DelayedMessageRow From(Dictionary<string, string> headers, byte[] body, TimeSpan dueAfter, string destination)
         {
             Guard.AgainstNull(nameof(destination), destination);
 
@@ -18,7 +18,7 @@
             headers["NServiceBus.SqlServer.ForwardDestination"] = destination;
             row.headers = DictionarySerializer.Serialize(headers);
             row.bodyBytes = body;
-            row.due = due;
+            row.dueAfter = dueAfter;
             return row;
         }
 
@@ -27,7 +27,7 @@
         {
             AddParameter(command, "Headers", SqlDbType.NVarChar, headers);
             AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes);
-            AddParameter(command, "Due", SqlDbType.DateTime, due);
+            AddParameter(command, "DueAfterMs", SqlDbType.BigInt, dueAfter.TotalMilliseconds);
         }
 
         void AddParameter(SqlCommand command, string name, SqlDbType type, object value)
@@ -37,6 +37,6 @@
 
         string headers;
         byte[] bodyBytes;
-        DateTime due;
+        TimeSpan dueAfter;
     }
 }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Transport.SQLServer
 
         public async Task Store(OutgoingMessage message, TimeSpan dueAfter, string destination, SqlConnection connection, SqlTransaction transaction)
         {
-            var messageRow = DelayedMessageRow.From(message.Headers, message.Body, dueAfter, destination);
+            var messageRow = StoreDelayedMessageCommand.From(message.Headers, message.Body, dueAfter, destination);
             using (var command = new SqlCommand(storeCommand, connection, transaction))
             {
                 messageRow.PrepareSendCommand(command);

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
@@ -15,9 +15,9 @@ namespace NServiceBus.Transport.SQLServer
 #pragma warning restore 618
         }
 
-        public async Task Store(OutgoingMessage message, DateTime dueTime, string destination, SqlConnection connection, SqlTransaction transaction)
+        public async Task Store(OutgoingMessage message, TimeSpan dueAfter, string destination, SqlConnection connection, SqlTransaction transaction)
         {
-            var messageRow = DelayedMessageRow.From(message.Headers, message.Body, dueTime, destination);
+            var messageRow = DelayedMessageRow.From(message.Headers, message.Body, dueAfter, destination);
             using (var command = new SqlCommand(storeCommand, connection, transaction))
             {
                 messageRow.PrepareSendCommand(command);

--- a/src/NServiceBus.SqlServer/DelayedDelivery/StoreDelayedMessageCommand.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/StoreDelayedMessageCommand.cs
@@ -5,15 +5,15 @@
     using System.Data;
     using System.Data.SqlClient;
 
-    class DelayedMessageRow
+    class StoreDelayedMessageCommand
     {
-        DelayedMessageRow() { }
+        StoreDelayedMessageCommand() { }
 
-        public static DelayedMessageRow From(Dictionary<string, string> headers, byte[] body, TimeSpan dueAfter, string destination)
+        public static StoreDelayedMessageCommand From(Dictionary<string, string> headers, byte[] body, TimeSpan dueAfter, string destination)
         {
             Guard.AgainstNull(nameof(destination), destination);
 
-            var row = new DelayedMessageRow();
+            var row = new StoreDelayedMessageCommand();
 
             headers["NServiceBus.SqlServer.ForwardDestination"] = destination;
             row.headers = DictionarySerializer.Serialize(headers);

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -51,7 +51,7 @@ INSERT INTO {0} (
 VALUES (
     @Headers,
     @Body,
-    @Due);
+    DATEADD(ms, @DueAfterMs, GETUTCDATE()));
 
 IF(@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF(@NOCOUNT = 'OFF') SET NOCOUNT OFF;";


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.SqlServer/issues/463

By using a timespan, the date conversion is done on the SQL instance that will also be checking for Due messages. Because the clock calculating the due date is the same clock that will be checking the due date, this will prevent clock drift from occurring with delayed delivery.