### PR TITLE
Warn not native

### DIFF
--- a/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.AcceptanceTests.NativeTimeouts
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using Logging;
+    using NUnit.Framework;
+    using Transport.SQLServer;
+
+    public class When_configuring_delayed_delivery : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_warn_when_timeoutmanager_is_configured_without_native_delayed_delivery()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<EndpointWithTimeoutManagerAndNotNative>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
+
+            var log = context.Logs.Single(l => l.Message.Contains("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`."));
+            Assert.AreEqual(LogLevel.Warn, log.Level);
+        }
+
+        [Test]
+        public async Task Should_not_warn_when_timeoutmanager_and_native_delayed_delivery_are_both_configured()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<EndpointWithTimeoutManagerAndNative>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
+
+            Assert.IsEmpty(context.Logs.Where(l => l.Message.Contains("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`.")));
+        }
+
+        [Test]
+        public async Task Should_not_warn_when_only_native_delayed_delivery_is_configured()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<EndpointWithOnlyNative>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
+
+            Assert.IsEmpty(context.Logs.Where(l => l.Message.Contains("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`.")));
+        }
+
+        public class EndpointWithTimeoutManagerAndNotNative : EndpointConfigurationBuilder
+        {
+            public EndpointWithTimeoutManagerAndNotNative()
+            {
+                EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
+            }
+        }
+
+        public class EndpointWithTimeoutManagerAndNative : EndpointConfigurationBuilder
+        {
+            public EndpointWithTimeoutManagerAndNative()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.UseTransport<SqlServerTransport>().UseNativeDelayedDelivery();
+                    config.EnableFeature<TimeoutManager>();
+                });
+            }
+        }
+
+        public class EndpointWithOnlyNative : EndpointConfigurationBuilder
+        {
+            public EndpointWithOnlyNative()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.UseTransport<SqlServerTransport>().UseNativeDelayedDelivery();
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
@@ -58,7 +58,7 @@
         }
 
         [Test]
-        public async Task Should_not_warn_when_both_native_delayed_delivery_and_timeoutmanage_is_configured_with_compatibility_disabled()
+        public async Task Should_not_warn_when_both_native_delayed_delivery_and_timeoutmanager_is_configured_with_compatibility_disabled()
         {
             Requires.MessageDrivenPubSub();
 

--- a/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
+++ b/src/NServiceBus.SqlServer.AcceptanceTests/NativeTimeouts/When_configuring_delayed_delivery.cs
@@ -83,7 +83,8 @@
             {
                 EndpointSetup<DefaultServer>(config =>
                 {
-                    config.UseTransport<SqlServerTransport>().UseNativeDelayedDelivery();
+                    var settings = config.UseTransport<SqlServerTransport>().UseNativeDelayedDelivery();
+                    settings.DisableTimeoutManagerCompatibility();
                 });
             }
         }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
-    using NServiceBus.Features;
-    using NServiceBus.Logging;
+    using Features;
+    using Logging;
     using Settings;
 
     static class DelayedDeliveryInfrastructure

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
@@ -1,11 +1,19 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
+    using NServiceBus.Features;
+    using NServiceBus.Logging;
     using Settings;
 
     static class DelayedDeliveryInfrastructure
     {
         public static StartupCheckResult CheckForInvalidSettings(SettingsHolder settings)
         {
+            var timeoutManagerEnabled = settings.IsFeatureEnabled(typeof(TimeoutManager));
+            if (timeoutManagerEnabled)
+            {
+                Logger.Warn("Current configuration of the endpoint uses TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery`.");
+            }
+
             var sendOnlyEndpoint = settings.GetOrDefault<bool>("Endpoint.SendOnly");
             if (sendOnlyEndpoint)
             {
@@ -13,5 +21,7 @@
             }
             return StartupCheckResult.Success;
         }
+
+        static ILog Logger = LogManager.GetLogger("DelayedDeliveryInfrastructure");
     }
 }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
@@ -8,7 +8,7 @@
     {
         public static StartupCheckResult CheckForInvalidSettings(SettingsHolder settings)
         {
-            var timeoutManagerEnabled = settings.IsFeatureEnabled(typeof(TimeoutManager));
+            var timeoutManagerEnabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
             if (timeoutManagerEnabled)
             {
                 Logger.Warn("Current configuration of the endpoint uses TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery`.");

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
@@ -8,12 +8,6 @@
     {
         public static StartupCheckResult CheckForInvalidSettings(SettingsHolder settings)
         {
-            var timeoutManagerEnabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
-            if (timeoutManagerEnabled)
-            {
-                Logger.Warn("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`.");
-            }
-
             var delayedDeliverySettings = settings.GetOrDefault<DelayedDeliverySettings>();
             if (delayedDeliverySettings != null)
             {
@@ -21,6 +15,14 @@
                 if (sendOnlyEndpoint)
                 {
                     return StartupCheckResult.Failed("Native delayed delivery is only supported for endpoints capable of receiving messages.");
+                }
+            }
+            else
+            {
+                var timeoutManagerEnabled = settings.IsFeatureActive(typeof(TimeoutManager));
+                if (timeoutManagerEnabled)
+                {
+                    Logger.Warn("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`.");
                 }
             }
 

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedDeliveryInfrastructure.cs
@@ -11,14 +11,19 @@
             var timeoutManagerEnabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
             if (timeoutManagerEnabled)
             {
-                Logger.Warn("Current configuration of the endpoint uses TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery`.");
+                Logger.Warn("Current configuration of the endpoint uses the TimeoutManager feature for delayed delivery - an option which is not recommended for new deployments. SqlTransport native delayed delivery should be used instead. It can be enabled by calling `UseNativeDelayedDelivery()`.");
             }
 
-            var sendOnlyEndpoint = settings.GetOrDefault<bool>("Endpoint.SendOnly");
-            if (sendOnlyEndpoint)
+            var delayedDeliverySettings = settings.GetOrDefault<DelayedDeliverySettings>();
+            if (delayedDeliverySettings != null)
             {
-                return StartupCheckResult.Failed("Native delayed delivery is only supported for endpoints capable of receiving messages.");
+                var sendOnlyEndpoint = settings.GetOrDefault<bool>("Endpoint.SendOnly");
+                if (sendOnlyEndpoint)
+                {
+                    return StartupCheckResult.Failed("Native delayed delivery is only supported for endpoints capable of receiving messages.");
+                }
             }
+
             return StartupCheckResult.Success;
         }
 

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Transport.SQLServer
     using System.Transactions;
     using DelayedDelivery;
     using Features;
-    using NServiceBus.Logging;
+    using Logging;
     using Performance.TimeToBeReceived;
     using Routing;
     using Settings;

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Transport.SQLServer
     using System.Transactions;
     using DelayedDelivery;
     using Features;
+    using NServiceBus.Logging;
     using Performance.TimeToBeReceived;
     using Routing;
     using Settings;
@@ -23,6 +24,11 @@ namespace NServiceBus.Transport.SQLServer
             schemaAndCatalogSettings = settings.GetOrCreate<EndpointSchemaAndCatalogSettings>();
             delayedDeliverySettings = settings.GetOrDefault<DelayedDeliverySettings>();
             var timeoutManagerFeatureDisabled = !settings.IsFeatureEnabled(typeof(TimeoutManager));
+
+            if (!timeoutManagerFeatureDisabled)
+            {
+                Logger.Warn("TimeoutManager feature has been enabled. SqlTransport supports delayed delivery natively and it is recommended to use the Native Timeout Manager instead.");
+            }
 
             diagnostics.Add("NServiceBus.Transport.SqlServer.TimeoutManager", new
             {
@@ -344,5 +350,6 @@ namespace NServiceBus.Transport.SQLServer
         DelayedMessageHandler delayedMessageHandler;
         DelayedDeliverySettings delayedDeliverySettings;
         Dictionary<string, object> diagnostics = new Dictionary<string, object>();
+        static ILog Logger = LogManager.GetLogger<SqlServerTransportInfrastructure>();
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -222,15 +222,7 @@ namespace NServiceBus.Transport.SQLServer
                     var dispatcher = new MessageDispatcher(new TableBasedQueueDispatcher(connectionFactory, queueOperationsReader), addressTranslator);
                     return dispatcher;
                 },
-                () =>
-                {
-                    var result = StartupCheckResult.Success;
-                    if (delayedDeliverySettings != null)
-                    {
-                        result = DelayedDeliveryInfrastructure.CheckForInvalidSettings(settings);
-                    }
-                    return Task.FromResult(result);
-                });
+                () => Task.FromResult(DelayedDeliveryInfrastructure.CheckForInvalidSettings(settings)));
         }
 
         DelayedMessageTable CreateDelayedMessageTable()

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -25,11 +25,6 @@ namespace NServiceBus.Transport.SQLServer
             delayedDeliverySettings = settings.GetOrDefault<DelayedDeliverySettings>();
             var timeoutManagerFeatureDisabled = !settings.IsFeatureEnabled(typeof(TimeoutManager));
 
-            if (!timeoutManagerFeatureDisabled)
-            {
-                Logger.Warn("TimeoutManager feature has been enabled. SqlTransport supports delayed delivery natively and it is recommended to use the Native Timeout Manager instead.");
-            }
-
             diagnostics.Add("NServiceBus.Transport.SqlServer.TimeoutManager", new
             {
                 FeatureEnabled = !timeoutManagerFeatureDisabled
@@ -350,6 +345,5 @@ namespace NServiceBus.Transport.SQLServer
         DelayedMessageHandler delayedMessageHandler;
         DelayedDeliverySettings delayedDeliverySettings;
         Dictionary<string, object> diagnostics = new Dictionary<string, object>();
-        static ILog Logger = LogManager.GetLogger<SqlServerTransportInfrastructure>();
     }
 }

--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.Transport.SQLServer
     using System.Transactions;
     using DelayedDelivery;
     using Features;
-    using Logging;
     using Performance.TimeToBeReceived;
     using Routing;
     using Settings;


### PR DESCRIPTION
Warns for https://github.com/Particular/NServiceBus.SqlServer/issues/468 if `TimeoutManager` is used.

Replaces #497