### PR TITLE
Fix DATEADD overflow by passing timespan parts to SQL layer

### DIFF
--- a/src/NServiceBus.SqlServer/DelayedDelivery/StoreDelayedMessageCommand.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/StoreDelayedMessageCommand.cs
@@ -27,7 +27,11 @@
         {
             AddParameter(command, "Headers", SqlDbType.NVarChar, headers);
             AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes);
-            AddParameter(command, "DueAfterMs", SqlDbType.BigInt, dueAfter.TotalMilliseconds);
+            AddParameter(command, "DueAfterDays", SqlDbType.Int, dueAfter.Days);
+            AddParameter(command, "DueAfterHours", SqlDbType.Int, dueAfter.Hours);
+            AddParameter(command, "DueAfterMinutes", SqlDbType.Int, dueAfter.Minutes);
+            AddParameter(command, "DueAfterSeconds", SqlDbType.Int, dueAfter.Seconds);
+            AddParameter(command, "DueAfterMilliseconds", SqlDbType.Int, dueAfter.Milliseconds);
         }
 
         void AddParameter(SqlCommand command, string name, SqlDbType type, object value)

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -44,6 +44,13 @@ DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
 SET NOCOUNT ON;
 
+DECLARE @DueAfter DATETIME = GETUTCDATE();
+SET @DueAfter = DATEADD(ms, @DueAfterMilliseconds, @DueAfter);
+SET @DueAfter = DATEADD(s, @DueAfterSeconds, @DueAfter);
+SET @DueAfter = DATEADD(n, @DueAfterMinutes, @DueAfter);
+SET @DueAfter = DATEADD(hh, @DueAfterHours, @DueAfter);
+SET @DueAfter = DATEADD(d, @DueAfterDays, @DueAfter);
+
 INSERT INTO {0} (
     Headers,
     Body,
@@ -51,7 +58,7 @@ INSERT INTO {0} (
 VALUES (
     @Headers,
     @Body,
-    DATEADD(ms, @DueAfterMs, GETUTCDATE()));
+    @DueAfter);
 
 IF(@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF(@NOCOUNT = 'OFF') SET NOCOUNT OFF;";


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.SqlServer/issues/504
Alternative to https://github.com/Particular/NServiceBus.SqlServer/pull/508

The previous maintenance release switched from `DateTime` to `TimeSpan`. This PR breaks the `TimeSpan` into its corresponding parts and passes those parts to the underlying SQL layer that then uses those to do `DATEADD` calculations. 

The benefit of this approach is the following:

- The TimeSpan is preserved
- The TimeSpan parts are ints
- There is no interpretation in the SQL layer needed thus no logic is done in the SQL and the parameters can be passed as is
- It is aligned with how the [DATEADD function](https://docs.microsoft.com/en-us/sql/t-sql/functions/dateadd-transact-sql) works because it operates on date parts
- It is aligned with the current design because the transport seems to do the logic in the translation layers in code where needed and not necessarily in SQL
- According to profiling no impact on the performance

