### PR TITLE
Fix DATEADD overflow by using a modulo divide approach

### DIFF
--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -44,8 +44,8 @@ DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
 SET NOCOUNT ON;
 
-DECLARE @ms int = @DueAfter%1000
-DECLARE @s int = @DueAfter/1000
+DECLARE @ms int = @DueAfterMs%1000
+DECLARE @s int = @DueAfterMs/1000
 DECLARE @DueAfter DATETIME = GETUTCDATE()
 SET @DueAfter = DATEADD(ms, @ms, @DueAfter)
 SET @DueAfter = DATEADD(s, @s, @DueAfter) -- Overflows at 68 years

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -46,7 +46,6 @@ SET NOCOUNT ON;
 
 DECLARE @ms int = @DueAfter%1000
 DECLARE @s int = @DueAfter/1000
-
 DECLARE @DueAfter DATETIME = GETUTCDATE()
 SET @DueAfter = DATEADD(ms, @ms, @DueAfter)
 SET @DueAfter = DATEADD(s, @s, @DueAfter) -- Overflows at 68 years

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -44,6 +44,13 @@ DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
 SET NOCOUNT ON;
 
+DECLARE @ms int = @DueAfter%1000
+DECLARE @s int = @DueAfter/1000
+
+DECLARE @DueAfter DATETIME = GETUTCDATE()
+SET @DueAfter = DATEADD(ms, @ms, @DueAfter)
+SET @DueAfter = DATEADD(s, @s, @DueAfter) -- Overflows at 68 years
+
 INSERT INTO {0} (
     Headers,
     Body,
@@ -51,7 +58,7 @@ INSERT INTO {0} (
 VALUES (
     @Headers,
     @Body,
-    DATEADD(ms, @DueAfterMs, GETUTCDATE()));
+    @DueAfter);
 
 IF(@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF(@NOCOUNT = 'OFF') SET NOCOUNT OFF;";


### PR DESCRIPTION
Fixes #504
Alternative to https://github.com/Particular/NServiceBus.SqlServer/pull/507

Pros:

- No c# changes, still passing to query as duration expressed in milliseconds
- One file change

Cons:

- Still vulnerable for overflow but at 68 years, but if needed, another moddiv could be added to divided on minutes to overflow at 4080 years :-)

