### PR TITLE
Always delay moving of delayed messages even when exceptions occur to honor the ProcessingInterval

### DIFF
--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
@@ -14,6 +14,7 @@ namespace NServiceBus.Transport.SQLServer
             this.connectionFactory = connectionFactory;
             this.interval = interval;
             this.batchSize = batchSize;
+            message = $"Scheduling next attempt to move matured delayed messages to input queue in {interval}";
         }
 
         public void Start()
@@ -64,16 +65,14 @@ namespace NServiceBus.Transport.SQLServer
                 }
                 finally
                 {
-                    if (!cancellationToken.IsCancellationRequested && Logger.IsDebugEnabled)
-                    {
-                        Logger.DebugFormat("Scheduling next attempt to move matured delayed messages to input queue in {0}", interval);
-                    }
+                    Logger.DebugFormat(message);
                     await Task.Delay(interval, cancellationToken).IgnoreCancellation()
                         .ConfigureAwait(false);
                 }
             }
         }
 
+        string message;
         DelayedMessageTable table;
         SqlConnectionFactory connectionFactory;
         TimeSpan interval;

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
@@ -54,13 +54,16 @@ namespace NServiceBus.Transport.SQLServer
                 {
                     // Graceful shutdown
                 }
-                catch (SqlException e) when (cancellationToken.IsCancellationRequested)
+                catch (Exception e) when (cancellationToken.IsCancellationRequested)
                 {
                     Logger.Debug("Exception thrown while performing cancellation", e);
                 }
                 catch (Exception e)
                 {
-                    Logger.Fatal("Exception thrown while performing cancellation", e);
+                    Logger.Fatal("Exception thrown while moving matured delayed messages", e);
+
+                    Logger.DebugFormat("Scheduling next attempt to move matured delayed messages to input queue in {0}", interval);
+                    await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Transport.SQLServer
                     {
                         using (var transaction = connection.BeginTransaction())
                         {
-                            await table.MoveMaturedMessages(batchSize, connection, transaction).ConfigureAwait(false);
+                            await table.MoveMaturedMessages(batchSize, connection, transaction, cancellationToken).ConfigureAwait(false);
                             transaction.Commit();
                         }
                     }
@@ -51,10 +51,12 @@ namespace NServiceBus.Transport.SQLServer
                 catch (OperationCanceledException)
                 {
                     // Graceful shutdown
+                    return;
                 }
                 catch (SqlException e) when (cancellationToken.IsCancellationRequested)
                 {
                     Logger.Debug("Exception thrown while performing cancellation", e);
+                    return;
                 }
                 catch (Exception e)
                 {

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageHandler.cs
@@ -62,7 +62,10 @@ namespace NServiceBus.Transport.SQLServer
                 }
                 finally
                 {
-                    Logger.DebugFormat("Scheduling next attempt to move matured delayed messages to input queue in {0}", interval);
+                    if (!cancellationToken.IsCancellationRequested && Logger.IsDebugEnabled)
+                    {
+                        Logger.DebugFormat("Scheduling next attempt to move matured delayed messages to input queue in {0}", interval);
+                    }
                     await Task.Delay(interval, cancellationToken).IgnoreCancellation()
                         .ConfigureAwait(false);
                 }

--- a/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
+++ b/src/NServiceBus.SqlServer/DelayedDelivery/DelayedMessageTable.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.SQLServer
 {
     using System;
     using System.Data.SqlClient;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transport;
 
@@ -25,12 +26,12 @@ namespace NServiceBus.Transport.SQLServer
             }
         }
 
-        public async Task MoveMaturedMessages(int batchSize, SqlConnection connection, SqlTransaction transaction)
+        public async Task MoveMaturedMessages(int batchSize, SqlConnection connection, SqlTransaction transaction, CancellationToken cancellationToken)
         {
             using (var command = new SqlCommand(moveMaturedCommand, connection, transaction))
             {
                 command.Parameters.AddWithValue("BatchSize", batchSize);
-                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.SqlServer/TaskEx.cs
+++ b/src/NServiceBus.SqlServer/TaskEx.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.SQLServer
 {
+    using System;
     using System.Threading.Tasks;
 
     static class TaskEx
@@ -9,6 +10,17 @@
         // using the returned value from async operations
         public static void Ignore(this Task task)
         {
+        }
+
+        public static async Task IgnoreCancellation(this Task task)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
 
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask


### PR DESCRIPTION
Fixes #501 
Alternative to https://github.com/Particular/NServiceBus.SqlServer/pull/502

This alternative makes sure that on the cancellation case the `Task.Delay` throwing an `OperationCanceledException` would not make the outer task `Cancelled` and thus bomb on shutting down