### PR TITLE
Ignore the sha of the commit that promoted incorrect version

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -8,3 +8,6 @@ branches:
     tracks-release-branches: true
   release:
     tag: ''
+ignore:
+  sha:
+    - e6ed46c7c9a17048039e4846eafe53be32b79c73


### PR DESCRIPTION
GitVersion bug workaround.
Similar to https://github.com/Particular/NServiceBus.RavenDB/pull/439