### PR TITLE
Fix startup check to always check for connection regardless of the mode

### DIFF
--- a/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.SqlServer/SqlServerTransportInfrastructure.cs
@@ -125,7 +125,7 @@ namespace NServiceBus.Transport.SQLServer
                     }
                     return new DelayedDeliveryQueueCreator(connectionFactory, creator, delayedMessageStore, createMessageBodyComputedColumn);
                 },
-                () => CheckForAmbientTransactionEnlistmentSupport(connectionFactory, scopeOptions.TransactionOptions));
+                () => CheckConnectivityAndForAmbientTransactionEnlistmentSupportIfNecessary(connectionFactory, scopeOptions.TransactionOptions));
         }
 
         SqlConnectionFactory CreateConnectionFactory()
@@ -172,7 +172,7 @@ namespace NServiceBus.Transport.SQLServer
             return new ExpiredMessagesPurger(_ => connectionFactory.OpenNewConnection(), purgeBatchSize, enable);
         }
 
-        async Task<StartupCheckResult> CheckForAmbientTransactionEnlistmentSupport(SqlConnectionFactory connectionFactory, TransactionOptions transactionOptions)
+        async Task<StartupCheckResult> CheckConnectivityAndForAmbientTransactionEnlistmentSupportIfNecessary(SqlConnectionFactory connectionFactory, TransactionOptions transactionOptions)
         {
             if (!settings.TryGet(out TransportTransactionMode requestedTransportTransactionMode))
             {


### PR DESCRIPTION
Potential fix for #517 if want to check the connection

This would make sure the behavior between the different transaction modes is always consistent when now SQL connection can be established.

Currently only when the transaction scope support is required we try to establish a connection and then a SQL Exception is thrown. For all other transport transaction modes no SQL connection is made and therefore a connection is tried to establish only in the background. This behavior is inconsistent between different transaction modes