### PR TITLE
Allow disabling delayed delivery

### DIFF
--- a/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.SqlServer/Configuration/SettingsKeys.cs
@@ -23,5 +23,10 @@
         /// For testing the migration process only
         /// </summary>
         public const string DisableNativePubSub = "SqlServer.DisableNativePubSub";
+
+        /// <summary>
+        /// For endpoints that only consume messages e.g. ServiceControl error
+        /// </summary>
+        public const string DisableDelayedDelivery = "SqlServer.DisableDelayedDelivery";
     }
 }

--- a/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.SqlServer/Receiving/QueueCreator.cs
@@ -31,8 +31,11 @@ namespace NServiceBus.Transport.SQLServer
                 {
                     await CreateQueue(SqlConstants.CreateQueueText, addressTranslator.Parse(sendingAddress), connection, transaction, createMessageBodyColumn).ConfigureAwait(false);
                 }
-            
-                await CreateQueue(SqlConstants.CreateDelayedMessageStoreText, delayedQueueAddress, connection, transaction, createMessageBodyColumn).ConfigureAwait(false);
+
+                if (delayedQueueAddress != null)
+                {
+                    await CreateQueue(SqlConstants.CreateDelayedMessageStoreText, delayedQueueAddress, connection, transaction, createMessageBodyColumn).ConfigureAwait(false);
+                }
                 transaction.Commit();
             }
         }


### PR DESCRIPTION
Delayed delivery needs to be disabled for some of the ServiceControl endpoints (such as staging queue processor and error ingestor)