### PR TITLE
set quoted identifier on

### DIFF
--- a/src/Scripts/Create-Databases.sql
+++ b/src/Scripts/Create-Databases.sql
@@ -1,3 +1,5 @@
+SET QUOTED_IDENTIFIER  ON
+
 CREATE DATABASE nservicebus
 GO
 USE nservicebus

--- a/src/Scripts/Reset-Database.sql
+++ b/src/Scripts/Reset-Database.sql
@@ -1,3 +1,5 @@
+SET QUOTED_IDENTIFIER  ON
+
 /* Drop all non-system stored procs */
 DECLARE @name VARCHAR(128)
 DECLARE @SQL VARCHAR(254)


### PR DESCRIPTION
Should fix the build problems when cleaning the database

```
following SET options have incorrect settings: 'QUOTED_IDENTIFIER'. Verify that SET options are correct for use with indexed views
```

apparently sqlcmd sets the [quoted identifiers to OFF](https://stackoverflow.com/questions/1137821/set-quoted-identifier-should-be-on-when-inserting-a-record) but the scripts need it ON for procedures and tables