### PR TITLE
Use correct ifdef for project's target frameworks

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
@@ -17,10 +17,10 @@ public class ConfigureSqlServerTransportInfrastructure : IConfigureTransportInfr
 {
     public TransportConfigurationResult Configure(SettingsHolder settings, TransportTransactionMode transportTransactionMode)
     {
-#if !NET46
+#if !NETFRAMEWORK
         if (transportTransactionMode == TransportTransactionMode.TransactionScope)
         {
-            NUnit.Framework.Assert.Ignore("TransactionScope not supported in net core");
+            NUnit.Framework.Assert.Ignore("TransactionScope not supported in .NET Core");
         }
 #endif
         this.settings = settings;


### PR DESCRIPTION
Looks like we overlooked this one when updating things for Microsoft.Data.SqlClient support.