### PR TITLE
Faster way to peek messages to retrieve message count (#480)

### DIFF
--- a/src/NServiceBus.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -53,6 +53,7 @@
         static async Task TryPeekQueueSize(TableBasedQueue tableBasedQueue)
         {
             await ExecuteInTransactionScope(async c => {
+                tableBasedQueue.FormatPeekCommand(100);
                 await tableBasedQueue.TryPeek(c, CancellationToken.None, PeekTimeoutInSeconds);
             });
         }

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -107,7 +107,7 @@ FROM (
     SELECT TOP {1} * 
     FROM {0} WITH (READPAST) 
     WHERE Expires IS NULL OR Expires > GETUTCDATE()
-);";
+) as count_table;";
 
         public static readonly string CreateQueueText = @"
 IF EXISTS (

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -103,9 +103,7 @@ IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
         public static readonly string PeekText = @"
 SELECT count(*) Id
-FROM {0} WITH (READPAST)
-WHERE Expires IS NULL
-    OR Expires > GETUTCDATE();";
+FROM (SELECT TOP {1} * FROM {0} WITH (READPAST)) as count_table";
 
         public static readonly string CreateQueueText = @"
 IF EXISTS (

--- a/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.SqlServer/Queuing/SqlConstants.cs
@@ -103,7 +103,11 @@ IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
         public static readonly string PeekText = @"
 SELECT count(*) Id
-FROM (SELECT TOP {1} * FROM {0} WITH (READPAST)) as count_table";
+FROM (
+    SELECT TOP {1} * 
+    FROM {0} WITH (READPAST) 
+    WHERE Expires IS NULL OR Expires > GETUTCDATE()
+);";
 
         public static readonly string CreateQueueText = @"
 IF EXISTS (

--- a/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.SqlServer/Queuing/TableBasedQueue.cs
@@ -17,7 +17,6 @@ namespace NServiceBus.Transport.SQLServer
 #pragma warning disable 618
             this.qualifiedTableName = qualifiedTableName;
             Name = queueName;
-            peekCommand = Format(SqlConstants.PeekText, this.qualifiedTableName);
             receiveCommand = Format(SqlConstants.ReceiveText, this.qualifiedTableName);
             sendCommand = Format(SqlConstants.SendText, this.qualifiedTableName);
             purgeCommand = Format(SqlConstants.PurgeText, this.qualifiedTableName);
@@ -37,6 +36,13 @@ namespace NServiceBus.Transport.SQLServer
                 var numberOfMessages = (int) await command.ExecuteScalarAsync(token).ConfigureAwait(false);
                 return numberOfMessages;
             }
+        }
+
+        public void FormatPeekCommand(int maxRecordsToPeek)
+        {
+#pragma warning disable 618
+            peekCommand = Format(SqlConstants.PeekText, qualifiedTableName, maxRecordsToPeek);
+#pragma warning restore 618
         }
 
         public virtual async Task<MessageReadResult> TryReceive(SqlConnection connection, SqlTransaction transaction)

--- a/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.SqlServer/Receiving/MessagePump.cs
@@ -52,6 +52,7 @@
 
         public void Start(PushRuntimeSettings limitations)
         {
+            inputQueue.FormatPeekCommand(Math.Min(100, 10 * limitations.MaxConcurrency));
             runningReceiveTasks = new ConcurrentDictionary<Task, Task>();
             concurrencyLimiter = new SemaphoreSlim(limitations.MaxConcurrency);
             cancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
Fixes #481

When peeking messages, we retrieve the count only up to the maximum concurrency level. This prevents the transport from effectively locking up if there are a lot of records to peek.