### PR TITLE
Transport can't be scaled-up due to page latch contention

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -247,6 +247,12 @@ FROM sys.indexes
 WHERE name = 'Index_Expires'
     AND object_id = OBJECT_ID('{0}')";
 
+        public static readonly string CheckIfIdRowVersionIndexIsPresent = @"
+SELECT COUNT(*)
+FROM sys.indexes
+WHERE name = 'Index_Id_RowVersion'
+    AND object_id = OBJECT_ID('{0}')";
+
         public static readonly string CheckHeadersColumnType = @"
 SELECT t.name
 FROM sys.columns c

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -181,7 +181,7 @@ CREATE CLUSTERED INDEX Index_Id_RowVersion ON {0}
 	[RowVersion] ASC
 )
 
-CREATE NONCLUSTERED INDEX IX_RowVersion ON {0}
+CREATE NONCLUSTERED INDEX Index_RowVersion ON {0}
 (
 	[RowVersion] ASC
 )

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -175,9 +175,15 @@ CREATE TABLE {0} (
     RowVersion bigint IDENTITY(1,1) NOT NULL
 );
 
-CREATE CLUSTERED INDEX Index_RowVersion ON {0}
+CREATE CLUSTERED INDEX Index_Id_RowVersion ON {0}
 (
-    RowVersion
+	[Id] ASC,
+	[RowVersion] ASC
+)
+
+CREATE NONCLUSTERED INDEX IX_RowVersion ON {0}
+(
+	[RowVersion] ASC
 )
 
 CREATE NONCLUSTERED INDEX Index_Expires ON {0}

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -241,12 +241,12 @@ FROM sys.indexes
 WHERE name = 'Index_Expires'
     AND object_id = OBJECT_ID('{0}')";
 
-        public static readonly string CheckIfIdRowVersionIndexIsPresent = @"
+        public static readonly string CheckIfNonClusteredRowVersionIndexIsPresent = @"
 SELECT COUNT(*)
 FROM sys.indexes
-WHERE name = 'Index_Id_RowVersion'
+WHERE name = 'Index_RowVersion'
     AND object_id = OBJECT_ID('{0}')
-    AND type = 1";
+    AND type = 2"; // 2 = non-clustered index
 
         public static readonly string CheckHeadersColumnType = @"
 SELECT t.name

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -175,12 +175,6 @@ CREATE TABLE {0} (
     RowVersion bigint IDENTITY(1,1) NOT NULL
 );
 
-CREATE CLUSTERED INDEX Index_Id_RowVersion ON {0}
-(
-	[Id] ASC,
-	[RowVersion] ASC
-)
-
 CREATE NONCLUSTERED INDEX Index_RowVersion ON {0}
 (
 	[RowVersion] ASC
@@ -251,7 +245,8 @@ WHERE name = 'Index_Expires'
 SELECT COUNT(*)
 FROM sys.indexes
 WHERE name = 'Index_Id_RowVersion'
-    AND object_id = OBJECT_ID('{0}')";
+    AND object_id = OBJECT_ID('{0}')
+    AND type = 1";
 
         public static readonly string CheckHeadersColumnType = @"
 SELECT t.name

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.Transport.SqlServer
             purgeCommand = Format(SqlConstants.PurgeText, this.qualifiedTableName);
             purgeExpiredCommand = Format(SqlConstants.PurgeBatchOfExpiredMessagesText, this.qualifiedTableName);
             checkExpiredIndexCommand = Format(SqlConstants.CheckIfExpiresIndexIsPresent, this.qualifiedTableName);
-            checkIdRowVersionIndexCommand = Format(SqlConstants.CheckIfIdRowVersionIndexIsPresent, this.qualifiedTableName);
+            checkNonClusteredRowVersionIndexCommand = Format(SqlConstants.CheckIfNonClusteredRowVersionIndexIsPresent, this.qualifiedTableName);
             checkHeadersColumnTypeCommand = Format(SqlConstants.CheckHeadersColumnType, this.qualifiedTableName);
 #pragma warning restore 618
         }
@@ -146,9 +146,9 @@ namespace NServiceBus.Transport.SqlServer
             }
         }
 
-        public async Task<bool> CheckIdRowVersionIndexPresence(SqlConnection connection)
+        public async Task<bool> CheckNonClusteredRowVersionIndexPresence(SqlConnection connection)
         {
-            using (var command = new SqlCommand(checkIdRowVersionIndexCommand, connection))
+            using (var command = new SqlCommand(checkNonClusteredRowVersionIndexCommand, connection))
             {
                 var rowsCount = (int) await command.ExecuteScalarAsync().ConfigureAwait(false);
                 return rowsCount > 0;
@@ -175,7 +175,7 @@ namespace NServiceBus.Transport.SqlServer
         string purgeCommand;
         string purgeExpiredCommand;
         string checkExpiredIndexCommand;
-        string checkIdRowVersionIndexCommand;
+        string checkNonClusteredRowVersionIndexCommand;
         string checkHeadersColumnTypeCommand;
     }
 }

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -25,7 +25,8 @@ namespace NServiceBus.Transport.SqlServer
             sendCommand = Format(SqlConstants.SendText, this.qualifiedTableName);
             purgeCommand = Format(SqlConstants.PurgeText, this.qualifiedTableName);
             purgeExpiredCommand = Format(SqlConstants.PurgeBatchOfExpiredMessagesText, this.qualifiedTableName);
-            checkIndexCommand = Format(SqlConstants.CheckIfExpiresIndexIsPresent, this.qualifiedTableName);
+            checkExpiredIndexCommand = Format(SqlConstants.CheckIfExpiresIndexIsPresent, this.qualifiedTableName);
+            checkIdRowVersionIndexCommand = Format(SqlConstants.CheckIfIdRowVersionIndexIsPresent, this.qualifiedTableName);
             checkHeadersColumnTypeCommand = Format(SqlConstants.CheckHeadersColumnType, this.qualifiedTableName);
 #pragma warning restore 618
         }
@@ -138,7 +139,16 @@ namespace NServiceBus.Transport.SqlServer
 
         public async Task<bool> CheckExpiresIndexPresence(SqlConnection connection)
         {
-            using (var command = new SqlCommand(checkIndexCommand, connection))
+            using (var command = new SqlCommand(checkExpiredIndexCommand, connection))
+            {
+                var rowsCount = (int) await command.ExecuteScalarAsync().ConfigureAwait(false);
+                return rowsCount > 0;
+            }
+        }
+
+        public async Task<bool> CheckIdRowVersionIndexPresence(SqlConnection connection)
+        {
+            using (var command = new SqlCommand(checkIdRowVersionIndexCommand, connection))
             {
                 var rowsCount = (int) await command.ExecuteScalarAsync().ConfigureAwait(false);
                 return rowsCount > 0;
@@ -164,7 +174,8 @@ namespace NServiceBus.Transport.SqlServer
         string sendCommand;
         string purgeCommand;
         string purgeExpiredCommand;
-        string checkIndexCommand;
+        string checkExpiredIndexCommand;
+        string checkIdRowVersionIndexCommand;
         string checkHeadersColumnTypeCommand;
     }
 }

--- a/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
@@ -19,7 +19,7 @@
         public async Task PerformInspection(TableBasedQueue queue)
         {
             await VerifyExpiredIndex(queue).ConfigureAwait(false);
-            await VerifyIdRowVersionIndex(queue).ConfigureAwait(false);
+            await VerifyNonClusteredRowVersionIndex(queue).ConfigureAwait(false);
             await VerifyHeadersColumnType(queue).ConfigureAwait(false);
         }
 
@@ -42,12 +42,12 @@
                 Logger.WarnFormat("Checking indexes on table {0} failed. Exception: {1}", queue, ex);
             }
         }
-        Task VerifyIdRowVersionIndex(TableBasedQueue queue)
+        Task VerifyNonClusteredRowVersionIndex(TableBasedQueue queue)
         {
             return VerifyIndex(
                 queue,
-                (q, c) => q.CheckIdRowVersionIndexPresence(c),
-                $"Table {queue.Name} does not contain index 'Index_Id_RowVersion'.{Environment.NewLine}Migrating to this clustered index better performance for send and receive operations.");
+                (q, c) => q.CheckNonClusteredRowVersionIndexPresence(c),
+                $"Table {queue.Name} does not contain non-clustered index 'Index_RowVersion'.{Environment.NewLine}Migrating to this non-clustered index improves performance for send and receive operations.");
         }
 
         Task VerifyExpiredIndex(TableBasedQueue queue)


### PR DESCRIPTION
### Overview

With the current index schema, there is a maximal throughput for a single queue and for the whole deployment that can't be increased by the scaling-up of the SQL server instance.  This is caused by the clustered index on the input queue that causes page latch contention on 

As a result, even a slight increase in message throughput can put a user in a position when scaling-up is not possible and other non-trivial actions e.g. transport infrastructure partitioning is required. 

### Solution

This PR removes the clustered index, changing the input queue table to a heap and introduces a secondary non-clustered index based on the `RowVersion` column to enable the message receives based on that index.

### Patched versions

Index creation script has been patched in the following versions of the transport:
 * [6.0.1](https://github.com/Particular/NServiceBus.SqlServer/releases/tag/6.0.1)
 * [5.0.3](https://github.com/Particular/NServiceBus.SqlServer/releases/tag/5.0.3)
 * [4.3.2](https://github.com/Particular/NServiceBus.SqlServer/releases/tag/4.3.2)
 * [3.1.5](https://github.com/Particular/NServiceBus.SqlServer/releases/tag/3.1.5)

For existing endpoints, [manual action](https://docs.particular.net/transports/upgrades/sqlserver-non-clustered-index) is required.
