### PR TITLE
Fix package name

### DIFF
--- a/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
+++ b/src/NServiceBus.SqlServer/NServiceBus.SqlServer.csproj
@@ -7,6 +7,7 @@
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\binaries\</OutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>NServiceBus.SqlServer</PackageId>
     <Description>SQL transport support for NServiceBus</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Since the AssemblyName is overridden in the project, it appears that default package id uses the assembly name instead of the project name like I thought.

This ensures that the correct package name is used.