### PR TITLE
Introduce a NoOpPurger as well as clearer diagnostic sections

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -37,9 +37,9 @@
                 m => new ProcessWithNoTransaction(sqlConnectionFactory, null),
                 qa => qa == "input" ? (TableBasedQueue)inputQueue : new TableBasedQueue(parser.Parse(qa).QualifiedTableName, qa),
                 new QueuePurger(sqlConnectionFactory),
-                new ExpiredMessagesPurger(_ => sqlConnectionFactory.OpenNewConnection(), 0, false),
+                new NoOpExpiredMessagesPurger(),
                 new QueuePeeker(sqlConnectionFactory, new QueuePeekerOptions()),
-                new SchemaInspector(_ => sqlConnectionFactory.OpenNewConnection()),
+                new SchemaInspector(_ => sqlConnectionFactory.OpenNewConnection(), false),
                 TimeSpan.MaxValue);
 
             await pump.Init(

--- a/src/NServiceBus.Transport.SqlServer/Receiving/ExpiredMessagesPurger.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/ExpiredMessagesPurger.cs
@@ -10,23 +10,16 @@
     using System.Threading.Tasks;
     using Logging;
 
-    class ExpiredMessagesPurger
+    class ExpiredMessagesPurger : IExpiredMessagesPurger
     {
-        public ExpiredMessagesPurger(Func<TableBasedQueue, Task<SqlConnection>> openConnection, int? purgeBatchSize, bool enable)
+        public ExpiredMessagesPurger(Func<TableBasedQueue, Task<SqlConnection>> openConnection, int? purgeBatchSize)
         {
             this.openConnection = openConnection;
-            this.enable = enable;
             this.purgeBatchSize = purgeBatchSize ?? DefaultPurgeBatchSize;
         }
 
         public async Task Purge(TableBasedQueue queue, CancellationToken cancellationToken)
         {
-            if (!enable)
-            {
-                Logger.DebugFormat("Purging expired messages on startup is not enabled for {0}.", queue);
-                return;
-            }
-
             Logger.DebugFormat("Starting a new expired message purge task for table {0}.", queue);
             var totalPurgedRowsCount = 0;
 
@@ -56,7 +49,6 @@
 
         int purgeBatchSize;
         Func<TableBasedQueue, Task<SqlConnection>> openConnection;
-        readonly bool enable;
         const int DefaultPurgeBatchSize = 10000;
         static ILog Logger = LogManager.GetLogger<ExpiredMessagesPurger>();
     }

--- a/src/NServiceBus.Transport.SqlServer/Receiving/IExpiredMessagesPurger.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/IExpiredMessagesPurger.cs
@@ -1,0 +1,10 @@
+﻿namespace NServiceBus.Transport.SqlServer
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    interface IExpiredMessagesPurger
+    {
+        Task Purge(TableBasedQueue queue, CancellationToken cancellationToken);
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/MessagePump.cs
@@ -14,7 +14,7 @@
 
     class MessagePump : IPushMessages
     {
-        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, Func<string, TableBasedQueue> queueFactory, IPurgeQueues queuePurger, ExpiredMessagesPurger expiredMessagesPurger, IPeekMessagesInQueue queuePeeker, SchemaInspector schemaInspector, TimeSpan waitTimeCircuitBreaker)
+        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, Func<string, TableBasedQueue> queueFactory, IPurgeQueues queuePurger, IExpiredMessagesPurger expiredMessagesPurger, IPeekMessagesInQueue queuePeeker, SchemaInspector schemaInspector, TimeSpan waitTimeCircuitBreaker)
         {
             this.receiveStrategyFactory = receiveStrategyFactory;
             this.queuePurger = queuePurger;
@@ -216,7 +216,7 @@
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
         IPurgeQueues queuePurger;
         Func<string, TableBasedQueue> queueFactory;
-        ExpiredMessagesPurger expiredMessagesPurger;
+        IExpiredMessagesPurger expiredMessagesPurger;
         IPeekMessagesInQueue queuePeeker;
         SchemaInspector schemaInspector;
         TimeSpan waitTimeCircuitBreaker;

--- a/src/NServiceBus.Transport.SqlServer/Receiving/NoOpExpiredMessagesPurger.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/NoOpExpiredMessagesPurger.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Transport.SqlServer
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class NoOpExpiredMessagesPurger: IExpiredMessagesPurger
+    {
+        public Task Purge(TableBasedQueue queue, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
@@ -11,14 +11,19 @@
 
     class SchemaInspector
     {
-        public SchemaInspector(Func<TableBasedQueue, Task<SqlConnection>> openConnection)
+        public SchemaInspector(Func<TableBasedQueue, Task<SqlConnection>> openConnection, bool validateExpiredIndex)
         {
             this.openConnection = openConnection;
+            this.validateExpiredIndex = validateExpiredIndex;
         }
 
         public async Task PerformInspection(TableBasedQueue queue)
         {
-            await VerifyExpiredIndex(queue).ConfigureAwait(false);
+            if (validateExpiredIndex)
+            {
+                await VerifyExpiredIndex(queue).ConfigureAwait(false);
+            }
+
             await VerifyNonClusteredRowVersionIndex(queue).ConfigureAwait(false);
             await VerifyHeadersColumnType(queue).ConfigureAwait(false);
         }
@@ -79,6 +84,7 @@
         }
 
         Func<TableBasedQueue, Task<SqlConnection>> openConnection;
+        readonly bool validateExpiredIndex;
         static ILog Logger = LogManager.GetLogger<ExpiredMessagesPurger>();
     }
 }


### PR DESCRIPTION
Backport of #656 to `release-6.1` branch

* Introduce a NoOpPurger as well as clearer diagnostic sections
* no Index_Expires verification when expired message purging is off
* Cleanup unnecessary code

Co-authored-by: lailabougria <laila.bougria@particular.net>
Co-authored-by: Tomek Masternak <tomasz.masternak@particular.net>