### PR TITLE
TransportTests: Use a ConcurrentQueue for now to track log items

### DIFF
--- a/src/NServiceBus.SqlServer.TransportTests/NServiceBus.SqlServer.TransportTests.csproj
+++ b/src/NServiceBus.SqlServer.TransportTests/NServiceBus.SqlServer.TransportTests.csproj
@@ -22,4 +22,10 @@
   <ItemGroup>
     <Compile Include="..\NServiceBus.Transport.SqlServer.TransportTests\**\*.cs" Exclude="**\obj\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Until Core 7.4.1 is out -->
+    <Compile Remove="\**\NSB.TransportTests\TransportTestLoggerFactory.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/NServiceBus.Transport.SqlServer.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/NServiceBus.Transport.SqlServer.TransportTests.csproj
@@ -18,4 +18,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Until Core 7.4.1 is out -->
+    <Compile Remove="\**\NSB.TransportTests\TransportTestLoggerFactory.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/TransportTestLoggerFactory.cs
@@ -1,0 +1,145 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using Logging;
+    using NUnit.Framework;
+
+    public class TransportTestLoggerFactory : ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public ConcurrentQueue<LogItem> LogItems { get; } = new ConcurrentQueue<LogItem>();
+
+        public class LogItem
+        {
+            // ReSharper disable once NotAccessedField.Global
+            public LogLevel Level;
+            // ReSharper disable once NotAccessedField.Global
+            public string Message;
+        }
+
+        class TransportTestLogger : ILog
+        {
+            public TransportTestLogger(string name, ConcurrentQueue<LogItem> logItems)
+            {
+                this.name = name;
+                this.logItems = logItems;
+            }
+
+            public bool IsDebugEnabled { get; } = true;
+            public bool IsInfoEnabled { get; } = true;
+            public bool IsWarnEnabled { get; } = true;
+            public bool IsErrorEnabled { get; } = true;
+            public bool IsFatalEnabled { get; } = true;
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                Log(LogLevel.Debug, $"{message} {exception}");
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Debug, string.Format(format, args));
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Info, string.Format(format, args));
+            }
+
+            public void Warn(string message)
+            {
+                Log(LogLevel.Warn, message);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                Log(LogLevel.Warn, $"{message} {exception}");
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Warn, string.Format(format, args));
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                Log(LogLevel.Error, $"{message} {exception}");
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Error, string.Format(format, args));
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Fatal, string.Format(format, args));
+            }
+
+            void Log(LogLevel level, string message)
+            {
+                logItems.Enqueue(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
+                TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
+            }
+
+            string name;
+            ConcurrentQueue<LogItem> logItems;
+        }
+    }
+
+    public static class ConcurrentQueueExtensions
+    {
+        public static void Clear(this ConcurrentQueue<TransportTestLoggerFactory.LogItem> queue)
+        {
+            while (!queue.IsEmpty)
+            {
+                queue.TryDequeue(out _);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can be reverted when https://github.com/Particular/NServiceBus/pull/5730 is merged and released