### PR TITLE
Change read code to support Always Encrypted

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
@@ -27,7 +27,7 @@
 
             await ResetQueue(addressParser, sqlConnectionFactory);
 
-            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName);
+            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, false);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
@@ -106,7 +106,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
         async Task PrepareAsync()
         {
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, null);
-            var tableCache = new TableBasedQueueCache(addressParser);
+            var tableCache = new TableBasedQueueCache(addressParser, true);
 
             await CreateOutputQueueIfNecessary(addressParser, sqlConnectionFactory);
 
@@ -119,8 +119,8 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
         {
             purger = new QueuePurger(sqlConnectionFactory);
             var queueAddress = addressTranslator.Parse(validAddress).QualifiedTableName;
-            queue = new TableBasedQueue(queueAddress, validAddress);
-
+            queue = new TableBasedQueue(queueAddress, validAddress, true);
+            
             return purger.Purge(queue);
         }
 

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -32,7 +32,7 @@
 
             await CreateQueueIfNotExists(addressParser, sqlConnectionFactory);
 
-            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName);
+            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, true);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -34,7 +34,7 @@
 
             var pump = new MessagePump(
                 m => new ProcessWithNoTransaction(sqlConnectionFactory, null),
-                qa => qa == "input" ? (TableBasedQueue)inputQueue : new TableBasedQueue(parser.Parse(qa).QualifiedTableName, qa),
+                qa => qa == "input" ? (TableBasedQueue)inputQueue : new TableBasedQueue(parser.Parse(qa).QualifiedTableName, qa, true),
                 new QueuePurger(sqlConnectionFactory),
                 new NoOpExpiredMessagesPurger(),
                 new QueuePeeker(sqlConnectionFactory, new QueuePeekerOptions()),
@@ -81,7 +81,7 @@
             int queueSize;
             int successfulReceives;
 
-            public FakeTableBasedQueue(string address, int queueSize, int successfulReceives) : base(address, "")
+            public FakeTableBasedQueue(string address, int queueSize, int successfulReceives) : base(address, "", true)
             {
                 this.queueSize = queueSize;
                 this.successfulReceives = successfulReceives;

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
@@ -121,7 +121,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
         async Task PrepareAsync()
         {
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, new QueueSchemaAndCatalogSettings());
-            var tableCache = new TableBasedQueueCache(addressParser);
+            var tableCache = new TableBasedQueueCache(addressParser, true);
 
             var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
             if (string.IsNullOrEmpty(connectionString))
@@ -142,7 +142,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
         {
             purger = new QueuePurger(sqlConnectionFactory);
             var queueAddress = addressParser.Parse(validAddress);
-            queue = new TableBasedQueue(queueAddress.QualifiedTableName, queueAddress.Address);
+            queue = new TableBasedQueue(queueAddress.QualifiedTableName, queueAddress.Address, true);
 
             return purger.Purge(queue);
         }

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
@@ -43,7 +43,7 @@ public class ConfigureSqlServerTransportInfrastructure : IConfigureTransportInfr
         var localAddress = settings.EndpointName();
         return new TransportConfigurationResult
         {
-            TransportInfrastructure = new SqlServerTransportInfrastructure("nservicebus", settings, connectionString, () => localAddress, () => logicalAddress)
+            TransportInfrastructure = new SqlServerTransportInfrastructure("nservicebus", settings, connectionString, () => localAddress, () => logicalAddress, false)
         };
     }
 

--- a/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
@@ -48,7 +48,6 @@
 
         static async Task<MessageRow> ReadRow(SqlDataReader dataReader)
         {
-            //HINT: we are assuming that dataReader is sequential. Order or reads is important !
             return new MessageRow
             {
                 id = await dataReader.GetFieldValueAsync<Guid>(0).ConfigureAwait(false),
@@ -95,15 +94,9 @@
             }
         }
 
-        static async Task<byte[]> GetBody(SqlDataReader dataReader, int bodyIndex)
+        static Task<byte[]> GetBody(SqlDataReader dataReader, int bodyIndex)
         {
-            // Null values will be returned as an empty (zero bytes) Stream.
-            using (var outStream = new MemoryStream())
-            using (var stream = dataReader.GetStream(bodyIndex))
-            {
-                await stream.CopyToAsync(outStream).ConfigureAwait(false);
-                return outStream.ToArray();
-            }
+            return Task.FromResult((byte[])dataReader[bodyIndex]);
         }
 
         static async Task<T> GetNullableAsync<T>(SqlDataReader dataReader, int index) where T : class

--- a/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
@@ -96,6 +96,7 @@
 
         static async Task<byte[]> GetBody(SqlDataReader dataReader, int bodyIndex)
         {
+            // Null values will be returned as an empty (zero bytes) Stream.
             using (var outStream = new MemoryStream())
             using (var stream = dataReader.GetStream(bodyIndex))
             {

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.Transport.SqlServer
         {
             using (var command = new SqlCommand(receiveCommand, connection, transaction))
             {
-                return await ReadMessage(command, isStreamSupported).ConfigureAwait(false);
+                return await ReadMessage(command).ConfigureAwait(false);
             }
         }
 
@@ -71,7 +71,7 @@ namespace NServiceBus.Transport.SqlServer
             return SendRawMessage(messageRow, connection, transaction);
         }
 
-        static async Task<MessageReadResult> ReadMessage(SqlCommand command, bool isStreamSupported)
+        async Task<MessageReadResult> ReadMessage(SqlCommand command)
         {
             var behavior = CommandBehavior.SingleRow;
             if (isStreamSupported)

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Transport.SqlServer
     {
         public string Name { get; }
 
-        public TableBasedQueue(string qualifiedTableName, string queueName)
+        public TableBasedQueue(string qualifiedTableName, string queueName, bool isStreamSupported)
         {
 #pragma warning disable 618
             this.qualifiedTableName = qualifiedTableName;
@@ -28,6 +28,7 @@ namespace NServiceBus.Transport.SqlServer
             checkExpiresIndexCommand = Format(SqlConstants.CheckIfExpiresIndexIsPresent, this.qualifiedTableName);
             checkNonClusteredRowVersionIndexCommand = Format(SqlConstants.CheckIfNonClusteredRowVersionIndexIsPresent, this.qualifiedTableName);
             checkHeadersColumnTypeCommand = Format(SqlConstants.CheckHeadersColumnType, this.qualifiedTableName);
+            this.isStreamSupported = isStreamSupported;
 #pragma warning restore 618
         }
 
@@ -54,7 +55,7 @@ namespace NServiceBus.Transport.SqlServer
         {
             using (var command = new SqlCommand(receiveCommand, connection, transaction))
             {
-                return await ReadMessage(command).ConfigureAwait(false);
+                return await ReadMessage(command, isStreamSupported).ConfigureAwait(false);
             }
         }
 
@@ -70,16 +71,22 @@ namespace NServiceBus.Transport.SqlServer
             return SendRawMessage(messageRow, connection, transaction);
         }
 
-        static async Task<MessageReadResult> ReadMessage(SqlCommand command)
+        static async Task<MessageReadResult> ReadMessage(SqlCommand command, bool isStreamSupported)
         {
-            using (var dataReader = await command.ExecuteReaderAsync(CommandBehavior.SingleRow).ConfigureAwait(false))
+            var behavior = CommandBehavior.SingleRow;
+            if (isStreamSupported)
+            {
+                behavior |= CommandBehavior.SequentialAccess;
+            }
+
+            using (var dataReader = await command.ExecuteReaderAsync(behavior).ConfigureAwait(false))
             {
                 if (!await dataReader.ReadAsync().ConfigureAwait(false))
                 {
                     return MessageReadResult.NoMessage;
                 }
 
-                return await MessageRow.Read(dataReader).ConfigureAwait(false);
+                return await MessageRow.Read(dataReader, isStreamSupported).ConfigureAwait(false);
             }
         }
 
@@ -176,5 +183,6 @@ namespace NServiceBus.Transport.SqlServer
         string checkExpiresIndexCommand;
         string checkNonClusteredRowVersionIndexCommand;
         string checkHeadersColumnTypeCommand;
+        bool isStreamSupported;
     }
 }

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -72,8 +72,7 @@ namespace NServiceBus.Transport.SqlServer
 
         static async Task<MessageReadResult> ReadMessage(SqlCommand command)
         {
-            // We need sequential access to not buffer everything into memory
-            using (var dataReader = await command.ExecuteReaderAsync(CommandBehavior.SingleRow | CommandBehavior.SequentialAccess).ConfigureAwait(false))
+            using (var dataReader = await command.ExecuteReaderAsync(CommandBehavior.SingleRow).ConfigureAwait(false))
             {
                 if (!await dataReader.ReadAsync().ConfigureAwait(false))
                 {

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueueCache.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueueCache.cs
@@ -5,21 +5,23 @@ namespace NServiceBus.Transport.SqlServer
 
     class TableBasedQueueCache
     {
-        public TableBasedQueueCache(QueueAddressTranslator addressTranslator)
+        public TableBasedQueueCache(QueueAddressTranslator addressTranslator, bool isStreamSupported)
         {
             this.addressTranslator = addressTranslator;
+            this.isStreamSupported = isStreamSupported;
         }
 
         public TableBasedQueue Get(string destination)
         {
             var address = addressTranslator.Parse(destination);
             var key = Tuple.Create(address.QualifiedTableName, address.Address);
-            var queue = cache.GetOrAdd(key, x => new TableBasedQueue(x.Item1, x.Item2));
+            var queue = cache.GetOrAdd(key, x => new TableBasedQueue(x.Item1, x.Item2, isStreamSupported));
 
             return queue;
         }
 
         QueueAddressTranslator addressTranslator;
         ConcurrentDictionary<Tuple<string, string>, TableBasedQueue> cache = new ConcurrentDictionary<Tuple<string, string>, TableBasedQueue>();
+        bool isStreamSupported;
     }
 }

--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransport.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransport.cs
@@ -43,8 +43,9 @@ namespace NServiceBus
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
             var catalog = GetDefaultCatalog(settings, connectionString);
+            var isEncrypted = IsEncrypted(connectionString);
 
-            return new SqlServerTransportInfrastructure(catalog, settings, connectionString, settings.LocalAddress, settings.LogicalAddress);
+            return new SqlServerTransportInfrastructure(catalog, settings, connectionString, settings.LocalAddress, settings.LogicalAddress, isEncrypted);
         }
 
         static string GetDefaultCatalog(SettingsHolder settings, string connectionString)
@@ -70,6 +71,21 @@ namespace NServiceBus
                 return (string)catalog;
             }
             throw new Exception("Initial Catalog property is mandatory in the connection string.");
+        }
+
+        static bool IsEncrypted(string connectionString)
+        {
+            var parser = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString
+            };
+
+            if (parser.TryGetValue("Column Encryption Setting", out var enabled))
+            {
+                return ((string)enabled).Equals("enabled", StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
I am not sure of the implications of this and would need someone more well versed in the history behind the need for sequential reads.

The reasons this is required are:

* When reading an encrypted column, `CommandBehavior.SequentialAccess` is not supported
* Without `CommandBehavior.SequentialAccess`, `SqlDataReader.GetStream` no longer works

This means that if we want to support having the headers and body columns and always encrypted columns, we need to stop using `CommandBehavior.SequentialAccess`.

Stopping the use of `CommandBehavior.SequentialAccess` means we have to stop using `GetStream`. Does typecasting to `byte[]` always work? I can't find references for when it would break down.

The PR only changes the code path when the `Column Encryption Setting` connection string parameter is enabled 