### PR TITLE
Better SchemaVerification index search

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -236,16 +236,20 @@ WHERE RowVersion
 
         public static readonly string CheckIfExpiresIndexIsPresent = @"
 SELECT COUNT(*)
-FROM sys.indexes
-WHERE name = 'Index_Expires'
-    AND object_id = OBJECT_ID('{0}')";
+FROM sys.indexes i
+INNER JOIN sys.index_columns AS ic ON ic.index_id = i.index_id AND ic.object_id = i.object_id AND ic.key_ordinal = 1
+INNER JOIN sys.columns AS c ON c.column_id = ic.column_id AND c.object_id = ic.object_id
+WHERE i.object_id = OBJECT_ID('{0}')
+AND c.name = 'Expires'";
 
         public static readonly string CheckIfNonClusteredRowVersionIndexIsPresent = @"
 SELECT COUNT(*)
-FROM sys.indexes
-WHERE name = 'Index_RowVersion'
-    AND object_id = OBJECT_ID('{0}')
-    AND type = 2"; // 2 = non-clustered index
+FROM sys.indexes i
+INNER JOIN sys.index_columns AS ic ON ic.index_id = i.index_id AND ic.object_id = i.object_id AND ic.key_ordinal = 1
+INNER JOIN sys.columns AS c ON c.column_id = ic.column_id AND c.object_id = ic.object_id
+WHERE i.object_id = OBJECT_ID('{0}')
+AND c.name = 'RowVersion'
+AND i.type = 2";
 
         public static readonly string CheckHeadersColumnType = @"
 SELECT t.name

--- a/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/SchemaVerification.cs
@@ -52,7 +52,7 @@
             return VerifyIndex(
                 queue,
                 (q, c) => q.CheckNonClusteredRowVersionIndexPresence(c),
-                $"Table {queue.Name} does not contain non-clustered index 'Index_RowVersion'.{Environment.NewLine}Migrating to this non-clustered index improves performance for send and receive operations.");
+                $"Table {queue.Name} does not contain non-clustered index for column 'RowVersion'.{Environment.NewLine}Migrating to this non-clustered index improves performance for send and receive operations.");
         }
 
         Task VerifyExpiredIndex(TableBasedQueue queue)
@@ -60,7 +60,7 @@
             return VerifyIndex(
                 queue,
                 (q, c) => q.CheckExpiresIndexPresence(c),
-                $"Table {queue.Name} does not contain index 'Index_Expires'.{Environment.NewLine}Adding this index will speed up the process of purging expired messages from the queue. Please consult the documentation for further information."
+                $"Table {queue.Name} does not contain index for column 'Expires'.{Environment.NewLine}Adding this index will speed up the process of purging expired messages from the queue. Please consult the documentation for further information."
             );
         }
 


### PR DESCRIPTION
SchemaVerification currently just searches for indexes on the queue table named `Index_Expires` and `Index_RowVersion` (the latter with a specific type).

Our deployment scripts create the correct indexes, but they are named differently. This gives false warnings on startup.

In this PR I have created queries that instead looks for an index, that have the specified column as its first element (key_ordinal=1), and for RowVersion still also checkes for non-clustered type. Apart from solving our own problem, it also solves the issue, that startup currently will not warn, if eg. Index_Expires exists but is designed wrongly.