### PR TITLE
change connection scope when using scoped trans

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Receiving/ProcessWithTransactionScope.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/ProcessWithTransactionScope.cs
@@ -25,15 +25,15 @@
                     using (var connection = await connectionFactory.OpenNewConnection().ConfigureAwait(false))
                     {
                         message = await TryReceive(connection, null, receiveCancellationTokenSource).ConfigureAwait(false);
+                    }
 
-                        if (message == null)
-                        {
-                            // The message was received but is not fit for processing (e.g. was DLQd).
-                            // In such a case we still need to commit the transport tx to remove message
-                            // from the queue table.
-                            scope.Complete();
-                            return;
-                        }
+                    if (message == null)
+                    {
+                        // The message was received but is not fit for processing (e.g. was DLQd).
+                        // In such a case we still need to commit the transport tx to remove message
+                        // from the queue table.
+                        scope.Complete();
+                        return;
                     }
 
                     if (!await TryProcess(message, PrepareTransportTransaction()).ConfigureAwait(false))


### PR DESCRIPTION
@SzymonPobiega regarding this https://discuss.particular.net/t/this-platform-does-not-support-distributed-transactions/1807/3

```
using (var conn = OpenConnection("DB2"))
using (var conn = OpenConnection("DB3"))
{
   //Do work in DB 2
   //Do work in DB 3
}

even if both connection string are identical you will get a DTC escalation.
```

would this PR reduce the likelihood of DTC escalation?
