### PR TITLE
defend against ExecuteScalarAsync returning unexpected values

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlCommandExtensions.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlCommandExtensions.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.Transport.SqlServer
+{
+    using System;
+#if SYSTEMDATASQLCLIENT
+    using System.Data.SqlClient;
+#else
+    using Microsoft.Data.SqlClient;
+#endif
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    static class SqlCommandExtensions
+    {
+        public static async Task<TScalar> ExecuteScalarAsyncOrDefault<TScalar>(this SqlCommand command, string commandName, Action<string> onUnexpectedValueMessage, CancellationToken cancellationToken = default)
+        {
+            var obj = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+            if (obj is null || Convert.IsDBNull(obj))
+            {
+                if (default(TScalar) != null)
+                {
+                    onUnexpectedValueMessage?.Invoke($"{commandName} returned a null value.");
+                }
+
+                return default;
+            }
+
+            if (!(obj is TScalar scalar))
+            {
+                onUnexpectedValueMessage?.Invoke($"{commandName} returned an unexpected value of type {obj.GetType()}.");
+
+                return default;
+            }
+
+            return scalar;
+        }
+
+        public static Task<TScalar> ExecuteScalarAsync<TScalar>(this SqlCommand command, string commandName, CancellationToken cancellationToken = default) =>
+            command.ExecuteScalarAsyncOrDefault<TScalar>(commandName, msg => throw new Exception(msg), cancellationToken);
+    }
+}


### PR DESCRIPTION
@kbaley @DavidBoike @kentdr this is a more generalised version of https://github.com/Particular/NServiceBus.SqlServer/pull/846 which also takes into account the recommendation to log warnings by @tmasternak and also covers the remaining calls to `ExecuteScalarAsync` as mentioned by @ramonsmits [here](https://github.com/Particular/NServiceBus.SqlServer/pull/847/files#r647179404) and [here](https://github.com/Particular/NServiceBus.SqlServer/pull/847/files#r647180005).

fixes https://github.com/Particular/NServiceBus.SqlServer/issues/848