### PR TITLE
Phase 1 of removing Recoverable/CorrelationId/ReplyToAddress columns

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -102,7 +102,7 @@
                 NumberOfReceives++;
 
                 var readResult = NumberOfReceives <= successfulReceives
-                    ? MessageReadResult.Success(new Message("1", string.Empty, null, new byte[0], false))
+                    ? MessageReadResult.Success(new Message("1", string.Empty, new byte[0], false))
                     : MessageReadResult.NoMessage;
 
                 return Task.FromResult(readResult);

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
@@ -1,0 +1,213 @@
+﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+{
+    using System;
+    using System.Collections.Generic;
+#if SYSTEMDATASQLCLIENT
+    using System.Data.SqlClient;
+#else
+    using Microsoft.Data.SqlClient;
+#endif
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Routing;
+    using Transport;
+    using SqlServer;
+    using System.Threading;
+
+    public class When_recoverable_column_is_removed
+    {
+        [TestCase(typeof(SendOnlyContextProvider), DispatchConsistency.Default)]
+        [TestCase(typeof(HandlerContextProvider), DispatchConsistency.Default)]
+        [TestCase(typeof(SendOnlyContextProvider), DispatchConsistency.Isolated)]
+        [TestCase(typeof(HandlerContextProvider), DispatchConsistency.Isolated)]
+        public async Task Should_recover(Type contextProviderType, DispatchConsistency dispatchConsistency)
+        {
+            // Setup
+
+            var token = CancellationToken.None;
+
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+            sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
+
+            var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, null);
+            var purger = new QueuePurger(sqlConnectionFactory);
+
+            await RemoveQueueIfPresent(ValidAddress, token);
+            await RemoveQueueIfPresent($"{ValidAddress}.Delayed", token);
+            await CreateOutputQueueIfNecessary(addressParser, sqlConnectionFactory);
+
+            var tableCache = new TableBasedQueueCache(addressParser, true);
+            var queue = tableCache.Get(ValidAddress);
+            dispatcher = new MessageDispatcher(addressParser, new NoOpMulticastToUnicastConverter(), tableCache, null, sqlConnectionFactory);
+
+            // Run normally
+            int messagesSent = await RunTest(contextProviderType, dispatchConsistency, queue, purger, token);
+            Assert.AreEqual(1, messagesSent);
+
+            // Remove Recoverable column
+            await DropRecoverableColumn(token);
+
+            var exception = Assert.ThrowsAsync<Exception>(() => RunTest(contextProviderType, dispatchConsistency, queue, purger, token));
+            Assert.True(exception.Message.Contains("change in the existence of the Recoverable column"));
+
+            // Try again, should work
+            int messagesSentAttempt2 = await RunTest(contextProviderType, dispatchConsistency, queue, purger, token);
+            Assert.AreEqual(1, messagesSentAttempt2);
+
+            // Put the Recoverable column back
+            await AddRecoverableColumn(token);
+
+            var exception2 = Assert.ThrowsAsync<Exception>(() => RunTest(contextProviderType, dispatchConsistency, queue, purger, token));
+            Assert.True(exception2.Message.Contains("change in the existence of the Recoverable column"));
+
+            // Try again, should work
+            int messagesSentAttempt3 = await RunTest(contextProviderType, dispatchConsistency, queue, purger, token);
+            Assert.AreEqual(1, messagesSentAttempt3);
+        }
+
+        async Task<int> RunTest(Type contextProviderType, DispatchConsistency dispatchConsistency, TableBasedQueue queue, QueuePurger purger, CancellationToken cancellationToken)
+        {
+            using (var contextProvider = CreateContext(contextProviderType, sqlConnectionFactory))
+            {
+                // Run with Recoverable column in place
+
+                var operations = new TransportOperations(CreateTransportOperation(id: "1", destination: ValidAddress, consistency: dispatchConsistency));
+                await dispatcher.Dispatch(operations, contextProvider.TransportTransaction, cancellationToken);
+                contextProvider.Complete();
+
+                return await purger.Purge(queue, cancellationToken);
+            }
+        }
+
+        async Task DropRecoverableColumn(CancellationToken cancellationToken)
+        {
+            var cmdText = $"ALTER TABLE {ValidAddress} DROP COLUMN Recoverable";
+            using (var connection = await sqlConnectionFactory.OpenNewConnection(cancellationToken))
+            using (var cmd = new SqlCommand(cmdText, connection))
+            {
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        async Task AddRecoverableColumn(CancellationToken cancellationToken)
+        {
+            var cmdText = $"ALTER TABLE {ValidAddress} ADD Recoverable bit NOT NULL";
+            using (var connection = await sqlConnectionFactory.OpenNewConnection(cancellationToken))
+            using (var cmd = new SqlCommand(cmdText, connection))
+            {
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        async Task RemoveQueueIfPresent(string queueName, CancellationToken cancellationToken)
+        {
+            var cmdText = $@"
+IF EXISTS (
+    SELECT *
+    FROM nservicebus.sys.objects
+    WHERE object_id = OBJECT_ID(N'{queueName}')
+        AND type in (N'U'))
+BEGIN
+    DROP TABLE nservicebus.dbo.[{queueName}]
+END";
+            using (var connection = await sqlConnectionFactory.OpenNewConnection(cancellationToken))
+            using (var cmd = new SqlCommand(cmdText, connection))
+            {
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        static IContextProvider CreateContext(Type contextType, SqlConnectionFactory sqlConnectionFactory)
+        {
+            return contextType == typeof(SendOnlyContextProvider) ? new SendOnlyContextProvider() : new HandlerContextProvider(sqlConnectionFactory);
+        }
+
+        static TransportOperation CreateTransportOperation(string id, string destination, DispatchConsistency consistency)
+        {
+            return new TransportOperation(
+                new OutgoingMessage(id, new Dictionary<string, string>(), new byte[0]),
+                new UnicastAddressTag(destination),
+                requiredDispatchConsistency: consistency
+                );
+        }
+
+        //Task PurgeOutputQueue(QueueAddressTranslator addressTranslator, CancellationToken cancellationToken = default)
+        //{
+        //    purger = new QueuePurger(sqlConnectionFactory);
+        //    var queueAddress = addressTranslator.Parse(ValidAddress).QualifiedTableName;
+        //    queue = new TableBasedQueue(queueAddress, ValidAddress, true);
+
+        //    return purger.Purge(queue, cancellationToken);
+        //}
+
+        static Task CreateOutputQueueIfNecessary(QueueAddressTranslator addressTranslator, SqlConnectionFactory sqlConnectionFactory, CancellationToken cancellationToken = default)
+        {
+            var queueCreator = new QueueCreator(sqlConnectionFactory, addressTranslator);
+
+            return queueCreator.CreateQueueIfNecessary(new[] { ValidAddress }, new CanonicalQueueAddress("Delayed", "dbo", "nservicebus"), cancellationToken);
+        }
+
+        MessageDispatcher dispatcher;
+        const string ValidAddress = "RecoverableColumnRemovalTable";
+
+        SqlConnectionFactory sqlConnectionFactory;
+
+        class NoOpMulticastToUnicastConverter : IMulticastToUnicastConverter
+        {
+            public Task<List<UnicastTransportOperation>> Convert(MulticastTransportOperation transportOperation, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(new List<UnicastTransportOperation>());
+            }
+        }
+
+        interface IContextProvider : IDisposable
+        {
+            ContextBag Context { get; }
+            TransportTransaction TransportTransaction { get; }
+            void Complete();
+        }
+
+        class SendOnlyContextProvider : IContextProvider
+        {
+            public virtual void Dispose()
+            {
+            }
+
+            public ContextBag Context { get; } = new ContextBag();
+            public TransportTransaction TransportTransaction { get; } = new TransportTransaction();
+
+            public virtual void Complete()
+            {
+            }
+        }
+
+        class HandlerContextProvider : SendOnlyContextProvider
+        {
+            public HandlerContextProvider(SqlConnectionFactory sqlConnectionFactory)
+            {
+                sqlConnection = sqlConnectionFactory.OpenNewConnection().GetAwaiter().GetResult();
+                sqlTransaction = sqlConnection.BeginTransaction();
+
+                TransportTransaction.Set(SettingsKeys.TransportTransactionSqlConnectionKey, sqlConnection);
+                TransportTransaction.Set(SettingsKeys.TransportTransactionSqlTransactionKey, sqlTransaction);
+
+                Context.Set(TransportTransaction);
+            }
+
+            public override void Dispose()
+            {
+                sqlTransaction.Dispose();
+                sqlConnection.Dispose();
+            }
+
+            public override void Complete()
+            {
+                sqlTransaction.Commit();
+            }
+
+            SqlTransaction sqlTransaction;
+            SqlConnection sqlConnection;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/Queuing/Message.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/Message.cs
@@ -4,13 +4,12 @@
 
     class Message
     {
-        public Message(string transportId, string originalHeaders, string replyToAddress, byte[] body, bool expired)
+        public Message(string transportId, string originalHeaders, byte[] body, bool expired)
         {
             TransportId = transportId;
             Body = body;
             Expired = expired;
             this.originalHeaders = originalHeaders;
-            this.replyToAddress = replyToAddress;
 
             InitializeHeaders();
         }
@@ -26,11 +25,6 @@
                 ? new Dictionary<string, string>()
                 : DictionarySerializer.DeSerialize(originalHeaders);
 
-            if (!string.IsNullOrEmpty(replyToAddress))
-            {
-                parsedHeaders[NServiceBus.Headers.ReplyToAddress] = replyToAddress;
-            }
-
             LegacyCallbacks.SubstituteReplyToWithCallbackQueueIfExists(parsedHeaders);
 
             Headers = parsedHeaders;
@@ -42,6 +36,5 @@
         }
 
         string originalHeaders;
-        string replyToAddress;
     }
 }

--- a/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/MessageRow.cs
@@ -28,8 +28,6 @@
             return new MessageRow
             {
                 id = Guid.NewGuid(),
-                correlationId = TryGetHeaderValue(headers, Headers.CorrelationId, s => s),
-                replyToAddress = TryGetHeaderValue(headers, Headers.ReplyToAddress, s => s),
                 timeToBeReceived = toBeReceived == TimeSpan.MaxValue ? null : (int?)toBeReceived.TotalMilliseconds,
                 headers = DictionarySerializer.Serialize(headers),
                 bodyBytes = body
@@ -40,8 +38,6 @@
         public void PrepareSendCommand(SqlCommand command)
         {
             AddParameter(command, "Id", SqlDbType.UniqueIdentifier, id);
-            AddParameter(command, "CorrelationId", SqlDbType.VarChar, correlationId);
-            AddParameter(command, "ReplyToAddress", SqlDbType.VarChar, replyToAddress);
             AddParameter(command, "TimeToBeReceivedMs", SqlDbType.Int, timeToBeReceived);
             AddParameter(command, "Headers", SqlDbType.NVarChar, headers);
             AddParameter(command, "Body", SqlDbType.VarBinary, bodyBytes, -1);
@@ -52,11 +48,9 @@
             return new MessageRow
             {
                 id = await dataReader.GetFieldValueAsync<Guid>(0, cancellationToken).ConfigureAwait(false),
-                correlationId = await GetNullableAsync<string>(dataReader, 1, cancellationToken).ConfigureAwait(false),
-                replyToAddress = await GetNullableAsync<string>(dataReader, 2, cancellationToken).ConfigureAwait(false),
-                expired = await dataReader.GetFieldValueAsync<int>(3, cancellationToken).ConfigureAwait(false) == 1,
-                headers = await GetHeaders(dataReader, 4, cancellationToken).ConfigureAwait(false),
-                bodyBytes = isStreamSupported ? await GetBody(dataReader, 5, cancellationToken).ConfigureAwait(false) : await GetNonStreamBody(dataReader, 5, cancellationToken).ConfigureAwait(false)
+                expired = await dataReader.GetFieldValueAsync<int>(1, cancellationToken).ConfigureAwait(false) == 1,
+                headers = await GetHeaders(dataReader, 2, cancellationToken).ConfigureAwait(false),
+                bodyBytes = isStreamSupported ? await GetBody(dataReader, 3, cancellationToken).ConfigureAwait(false) : await GetNonStreamBody(dataReader, 5, cancellationToken).ConfigureAwait(false)
             };
         }
 
@@ -64,22 +58,13 @@
         {
             try
             {
-                return MessageReadResult.Success(new Message(id.ToString(), headers, replyToAddress, bodyBytes, expired));
+                return MessageReadResult.Success(new Message(id.ToString(), headers, bodyBytes, expired));
             }
             catch (Exception ex)
             {
                 Logger.Error("Error receiving message. Probable message metadata corruption. Moving to error queue.", ex);
                 return MessageReadResult.Poison(this);
             }
-        }
-
-        static T TryGetHeaderValue<T>(Dictionary<string, string> headers, string name, Func<string, T> conversion)
-        {
-            if (headers.TryGetValue(name, out var text))
-            {
-                return conversion(text);
-            }
-            return default;
         }
 
         static async Task<string> GetHeaders(SqlDataReader dataReader, int headersIndex, CancellationToken cancellationToken)
@@ -112,16 +97,6 @@
             return Task.FromResult((byte[])dataReader[bodyIndex]);
         }
 
-        static async Task<T> GetNullableAsync<T>(SqlDataReader dataReader, int index, CancellationToken cancellationToken) where T : class
-        {
-            if (await dataReader.IsDBNullAsync(index, cancellationToken).ConfigureAwait(false))
-            {
-                return default;
-            }
-
-            return await dataReader.GetFieldValueAsync<T>(index, cancellationToken).ConfigureAwait(false);
-        }
-
         void AddParameter(SqlCommand command, string name, SqlDbType type, object value)
         {
             command.Parameters.Add(name, type).Value = value ?? DBNull.Value;
@@ -133,8 +108,6 @@
         }
 
         Guid id;
-        string correlationId;
-        string replyToAddress;
         bool expired;
         int? timeToBeReceived;
         string headers;

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.SqlServer
     {
         public static readonly string PurgeText = "DELETE FROM {0}";
 
-        public static readonly string SendText =
+        public static readonly string SendTextWithRecoverable =
             @"
 DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
@@ -12,16 +12,12 @@ SET NOCOUNT ON;
 
 INSERT INTO {0} (
     Id,
-    CorrelationId,
-    ReplyToAddress,
     Recoverable,
     Expires,
     Headers,
     Body)
 VALUES (
     @Id,
-    @CorrelationId,
-    @ReplyToAddress,
     1,
     CASE WHEN @TimeToBeReceivedMs IS NOT NULL
         THEN DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()) END,
@@ -30,6 +26,29 @@ VALUES (
 
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
+
+        public static readonly string SendText =
+            @"
+DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
+IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON'
+SET NOCOUNT ON;
+
+INSERT INTO {0} (
+    Id,
+    Expires,
+    Headers,
+    Body)
+VALUES (
+    @Id,
+    CASE WHEN @TimeToBeReceivedMs IS NOT NULL
+        THEN DATEADD(ms, @TimeToBeReceivedMs, GETUTCDATE()) END,
+    @Headers,
+    @Body);
+
+IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
+IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
+
+        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
 
         public static readonly string StoreDelayedMessageText =
 @"
@@ -68,8 +87,6 @@ WITH message AS (
 DELETE FROM message
 OUTPUT
     deleted.Id,
-    deleted.CorrelationId,
-    deleted.ReplyToAddress,
     CASE WHEN deleted.Expires IS NULL
         THEN 0
         ELSE CASE WHEN deleted.Expires > GETUTCDATE()
@@ -138,7 +155,7 @@ BEGIN
     RETURN
 END
 
-ALTER TABLE {0} 
+ALTER TABLE {0}
 ADD BodyString as cast(Body as nvarchar(max));
 
 EXEC sp_releaseapplock @Resource = '{0}_lock'";

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueue.cs
@@ -88,10 +88,10 @@ namespace NServiceBus.Transport.SqlServer
 
         async Task SendRawMessage(MessageRow message, SqlConnection connection, SqlTransaction transaction, CancellationToken cancellationToken)
         {
-            await EnsureSendCommandReady(connection, transaction, cancellationToken).ConfigureAwait(false);
-
             try
             {
+                await EnsureSendCommandReady(connection, transaction, cancellationToken).ConfigureAwait(false);
+
                 using (var command = new SqlCommand(sendCommand, connection, transaction))
                 {
                     message.PrepareSendCommand(command);


### PR DESCRIPTION
* Stops using CorrelationId/ReplyToAddress columns except in table creation
* Determines if each table contains a Recoverable column and adjusts Send command to match

Couldn't be removed until a later major, once all endpoints were running the major containing this PR.