### PR TITLE
ensure and align default connection string for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Consider creating a RAM drive or using the temporaty drive when running in a clo
 
 ## How to run tests
 
-Tests expect a Sql Server instance (default: `.\SqlExpress`) to be available, and by default use the following connection string: `Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True`. It is possible to configure a different connection string by setting it as the value of the `SqlServerTransportConnectionString` environment variable. The initial catalog, `nservicebus`, is hardcoded in some tests and cannot be changed.
+The tests expect a SQL Server instance to be available.
+
+All tests use the default connection string `Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True`. This can be changed by setting the `SqlServerTransportConnectionString` environment variable. The initial catalog, `nservicebus`, is hardcoded in some tests and cannot be changed.
 
 ### Requirements
 

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
@@ -19,12 +19,7 @@ public class ConfigureEndpointSqlServerTransport : IConfigureEndpointTestExecuti
 
     public ConfigureEndpointSqlServerTransport()
     {
-        var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-
-        if (string.IsNullOrEmpty(connectionString))
-        {
-            throw new Exception("The 'SqlServerTransportConnectionString' environment variable is not set.");
-        }
+        var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         transport = new SqlServerTransport(connectionString);
         transport.Subscriptions.DisableCaching = true;

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiCatalog/MultiCatalogAcceptanceTest.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiCatalog/MultiCatalogAcceptanceTest.cs
@@ -10,15 +10,8 @@
 
     public class MultiCatalogAcceptanceTest : NServiceBusAcceptanceTest
     {
-        protected static string GetDefaultConnectionString()
-        {
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;";
-            }
-            return connectionString;
-        }
+        protected static string GetDefaultConnectionString() =>
+            Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         protected static string WithCustomCatalog(string connectionString, string catalog)
         {

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_for_legacy_publisher.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_for_legacy_publisher.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Transport.SqlServer.AcceptanceTests.MultiSchema
 
     public class When_custom_schema_configured_for_legacy_publisher : NServiceBusAcceptanceTest
     {
-        static string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public Task Should_receive_event()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -16,7 +16,7 @@
     public class When_migrating_publisher_first : NServiceBusAcceptanceTest
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(Publisher));
-        static string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_not_lose_any_events()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -16,7 +16,7 @@
     public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(Publisher));
-        static string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string _connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_not_lose_any_events()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
@@ -15,7 +15,7 @@
     public class When_publisher_runs_in_compat_mode : NServiceBusAcceptanceTest
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(MigratedPublisher));
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Legacy_subscriber_can_subscribe()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
@@ -12,7 +12,7 @@
     public class When_subscriber_runs_in_compat_mode : NServiceBusAcceptanceTest
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(LegacyPublisher));
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task It_can_subscribe_for_event_published_by_legacy_publisher()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/TimeToBeReceived/When_queue_contains_expired_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/TimeToBeReceived/When_queue_contains_expired_messages.cs
@@ -17,14 +17,8 @@
     public class When_queue_contains_expired_messages : NServiceBusAcceptanceTest
     {
         [SetUp]
-        public void SetUpConnectionString()
-        {
-            connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;";
-            }
-        }
+        public void SetUpConnectionString() =>
+            connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
 #if NETFRAMEWORK
         [TestCase(TransportTransactionMode.TransactionScope)]

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_a_corrupted_message_is_received.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_a_corrupted_message_is_received.cs
@@ -20,14 +20,8 @@
     public class When_a_corrupted_message_is_received : NServiceBusAcceptanceTest
     {
         [SetUp]
-        public void SetConnectionString()
-        {
-            connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;";
-            }
-        }
+        public void SetConnectionString() =>
+            connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
 #if NETFRAMEWORK
         [TestCase(TransportTransactionMode.TransactionScope)]

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_connection_in_receive_context.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_connection_in_receive_context.cs
@@ -15,7 +15,7 @@
 
     public class When_passing_custom_connection_in_receive_context : NServiceBusAcceptanceTest
     {
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_use_connection_in_transport_operations()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_connection_outside_receive_context.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_connection_outside_receive_context.cs
@@ -15,7 +15,7 @@
 
     public class When_passing_custom_connection_outside_receive_context : NServiceBusAcceptanceTest
     {
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_use_connection_for_all_transport_operations()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_transaction_in_receive_context.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_transaction_in_receive_context.cs
@@ -15,7 +15,7 @@
 
     public class When_passing_custom_transaction_in_receive_context : NServiceBusAcceptanceTest
     {
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_use_transaction_in_transport_operations()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_transaction_outside_receive_context.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_passing_custom_transaction_outside_receive_context.cs
@@ -14,7 +14,7 @@
 
     public class When_passing_custom_transaction_outside_receive_context : NServiceBusAcceptanceTest
     {
-        static string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+        static readonly string ConnectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         [Test]
         public async Task Should_use_transaction_in_transport_operations()

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_using_custom_connection_factory.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/When_using_custom_connection_factory.cs
@@ -25,15 +25,8 @@
             Assert.True(ctx.MessageReceived, "Message should be properly received");
         }
 
-        static string GetConnectionString()
-        {
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;";
-            }
-            return connectionString;
-        }
+        static string GetConnectionString() =>
+            Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         public class Endpoint : EndpointConfigurationBuilder
         {

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
@@ -17,11 +17,7 @@
         {
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, null);
 
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-            }
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
             sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
 

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
@@ -90,11 +90,7 @@
         [SetUp]
         public void Prepare()
         {
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-            }
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
             sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
 

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -22,11 +22,7 @@
         {
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, null);
 
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-            }
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
             sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
 

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -26,11 +26,7 @@
             var inputQueueAddress = parser.Parse("input").Address;
             var inputQueue = new FakeTableBasedQueue(inputQueueAddress, queueSize, successfulReceives);
 
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-            }
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
             var transport = new SqlServerTransport(SqlConnectionFactory.Default(connectionString).OpenNewConnection)
             {

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
@@ -27,7 +27,7 @@
 
             var token = CancellationToken.None;
 
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
             sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
 
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, null);

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
@@ -119,11 +119,7 @@
             var addressParser = new QueueAddressTranslator("nservicebus", "dbo", null, new QueueSchemaAndCatalogOptions());
             var tableCache = new TableBasedQueueCache(addressParser, true);
 
-            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-            }
+            var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
             sqlConnectionFactory = SqlConnectionFactory.Default(connectionString);
 

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/ConfigureSqlServerTransportInfrastructure.cs
@@ -14,12 +14,7 @@ public class ConfigureSqlServerTransportInfrastructure : IConfigureTransportInfr
 {
     public TransportDefinition CreateTransportDefinition()
     {
-        connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString");
-
-        if (string.IsNullOrEmpty(connectionString))
-        {
-            connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
-        }
+        connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
 
         return new SqlServerTransport(connectionString);
     }


### PR DESCRIPTION
Similar to https://github.com/Particular/NServiceBus.RabbitMQ/pull/839

Another WTF here is that the reading of the env var is spread across so many places, but I didn't want to tackle that here.