### PR TITLE
Handle delayed message with invalid destination

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_deferring_a_message_to_invalid_queue.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_deferring_a_message_to_invalid_queue.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.Transport.SqlServer.AcceptanceTests.NativeTimeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Faults;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_to_invalid_queue : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_forward_it_to_the_error_queue()
+        {
+            var delay = TimeSpan.FromSeconds(5); //To make sure it is actually stored
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.DoNotFailOnErrorMessages().When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(delay);
+                    options.SetDestination("InvalidDestination__");
+
+                    return session.Send(new MyMessage(), options);
+                }))
+                .WithEndpoint<ErrorSpy>()
+                .Done(c => c.MessageForwardedToErrorQueue)
+                .Run();
+
+            Assert.IsTrue(context.MessageForwardedToErrorQueue);
+            Assert.AreEqual("InvalidDestination__", context.Headers[FaultsHeaderKeys.FailedQ]);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageForwardedToErrorQueue { get; set; }
+            public IReadOnlyDictionary<string, string> Headers { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
+                });
+            }
+        }
+
+        public class ErrorSpy : EndpointConfigurationBuilder
+        {
+            public ErrorSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class Handler : IHandleMessages<MyMessage>
+            {
+                readonly Context scenarioContext;
+                public Handler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.Headers = context.MessageHeaders;
+                    scenarioContext.MessageForwardedToErrorQueue = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/ExceptionExtensions.cs
+++ b/src/NServiceBus.Transport.SqlServer/ExceptionExtensions.cs
@@ -11,6 +11,18 @@ namespace NServiceBus
 
     static class ExceptionExtensions
     {
+        public static string GetMessage(this Exception exception)
+        {
+            try
+            {
+                return exception.Message;
+            }
+            catch (Exception)
+            {
+                return $"Could not read Message from exception type '{exception.GetType()}'.";
+            }
+        }
+
         // the SQL client sometimes throws an SqlException when operations are canceled instead of an OperationCanceledException
 #pragma warning disable PS0003 // A parameter of type CancellationToken on a non-private delegate or method should be optional
         public static bool IsCausedBy(this Exception ex, CancellationToken cancellationToken) =>

--- a/src/NServiceBus.Transport.SqlServer/Receiving/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Transport.SqlServer/Receiving/ExceptionHeaderHelper.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Transport.SqlServer
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    static class ExceptionHeaderHelper
+    {
+        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e)
+        {
+            headers["NServiceBus.ExceptionInfo.ExceptionType"] = e.GetType().FullName;
+
+            if (e.InnerException != null)
+            {
+                headers["NServiceBus.ExceptionInfo.InnerExceptionType"] = e.InnerException.GetType().FullName;
+            }
+
+            headers["NServiceBus.ExceptionInfo.HelpLink"] = e.HelpLink;
+            headers["NServiceBus.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
+            headers["NServiceBus.ExceptionInfo.Source"] = e.Source;
+            headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
+            headers["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
+
+            foreach (DictionaryEntry entry in e.Data)
+            {
+                if (entry.Value == null)
+                {
+                    continue;
+                }
+                headers["NServiceBus.ExceptionInfo.Data." + entry.Key] = entry.Value.ToString();
+            }
+        }
+
+        static string Truncate(this string value, int maxLength) =>
+            string.IsNullOrEmpty(value)
+                ? value
+                : value.Length <= maxLength
+                    ? value
+                    : value.Substring(0, maxLength);
+    }
+}


### PR DESCRIPTION
by moving them to the error queue with all the exception headers set and the FailedQ header pointing to the (invalid) destination queue