### PR TITLE
Update Microsoft.Data.SqlClient to 5.1.4

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/NServiceBus.Transport.SqlServer.csproj
+++ b/src/NServiceBus.Transport.SqlServer/NServiceBus.Transport.SqlServer.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="9.0.0-alpha.9" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0-preview4.23342.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Looks like [Microsoft.Data.SqlClient 5.1.4 includes the DTC deadlock fix](https://github.com/dotnet/SqlClient/releases/tag/v5.1.4), so we no longer need to reference the 5.2 preview.