### PR TITLE
READPAST,READCOMMITTEDLOCK instead of NOLOCK to not read uncommitted data

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -48,7 +48,7 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
+        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (READPAST, READCOMMITTEDLOCK);";
 
         public static readonly string StoreDelayedMessageText =
 @"
@@ -121,7 +121,7 @@ FROM {0} WITH (READPAST)
 ORDER BY Due";
 
         public static readonly string PeekText = @"
-SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (READPAST)";
+SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (READPAST, READCOMMITTEDLOCK)";
 
         public static readonly string AddMessageBodyStringColumn = @"
 IF NOT EXISTS (

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -48,7 +48,7 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (READPAST);";
+        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
 
         public static readonly string StoreDelayedMessageText =
 @"
@@ -121,7 +121,7 @@ FROM {0} WITH (READPAST)
 ORDER BY Due";
 
         public static readonly string PeekText = @"
-SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (nolock)";
+SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (READPAST)";
 
         public static readonly string AddMessageBodyStringColumn = @"
 IF NOT EXISTS (

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -48,7 +48,7 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (READPAST, READCOMMITTEDLOCK);";
+        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
 
         public static readonly string StoreDelayedMessageText =
 @"

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -48,7 +48,7 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
+        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (READPAST);";
 
         public static readonly string StoreDelayedMessageText =
 @"


### PR DESCRIPTION
- Related to #863 

Backports:

- #1292 
- #1278

The updated peek query will ignore rows
- for messages that are currently being inserted within an uncommitted transaction
- currently being locked by, for example, another competing consumer

This can happen when a sender sends a large batch of messages. The query that calculates how many "messages" are available to be fetched previously would read uncommitted data and continuously fire queries to fetch new messages but not receive any new data because the data was not yet committed.

## Why READCOMMITTEDLOCK ?

The hint `READCOMMITTEDLOCK`is required when the database has snapshot isolation enabled, which is the default in SQL Azure instances. Previously any consumer would DELETE. Because the peek used `NOLOCK` the result would exclude the deleted rows. However, with snapshot isolation, the delete will ONLY be removed AFTER the transaction is committed. Using `READCOMMITTEDLOCK` ensures that `READPAST` will exclude any active uncommitted DELETE.

## SQL Execution plans

In the past, the MIN/MAX with NOLOCK was applied instead of a COUNT with READPAST because in ServiceControl its queue length calculation was performing better. The big difference however is that doing a FULL count on the index while the prior count was only based on a TOP X. Very likely SQLT its peek operation was not causing the same issue as with SC's queue length calculation.

- https://github.com/Particular/NServiceBus.SqlServer/pull/631
- https://github.com/Particular/ServiceControl/pull/1860

Still, documenting this as the original was using READPAST, the previous used NOLOCK and this PR uses READPAST again. The actual execution plan shows very similar plans for all revisions:

![image](https://github.com/Particular/NServiceBus.SqlServer/assets/152998/d61d22b8-8559-4cb1-bcc2-e47701465290)
