### PR TITLE
READPAST,READCOMMITTEDLOCK instead of NOLOCK to not read uncommitted data - 7.0

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -121,7 +121,7 @@ FROM {0} WITH (READPAST)
 ORDER BY Due";
 
         public static readonly string PeekText = @"
-SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (nolock)";
+SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) Id FROM {0} WITH (READPAST, READCOMMITTEDLOCK)";
 
         public static readonly string AddMessageBodyStringColumn = @"
 IF NOT EXISTS (


### PR DESCRIPTION
- Backport of #1277 for release branch `release-7.0` to be released in version 7.0.5