### PR TITLE
Fix bug in BackOffStrategy that can lead to infinite wait time

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 
-public class BackOffStrategy(TimeProvider timeProvider = null)
+class BackOffStrategy(TimeProvider timeProvider = null)
 {
     public void RegisterNewDueTime(DateTime dueTime)
     {

--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -37,9 +37,9 @@ public class BackOffStrategy(TimeProvider timeProvider = null)
 
         // While running this loop, a new delayed message can be stored
         // and NextExecutionTime could be set to a new (sooner) time.
-        while (now < NextExecutionTime)
+        TimeSpan waitTime;
+        while ((waitTime = NextExecutionTime - now) > TimeSpan.Zero)
         {
-            var waitTime = NextExecutionTime - now;
             waitTime = waitTime < oneSecond ? waitTime : oneSecond;
             await Task.Delay(waitTime, timeProvider, cancellationToken).ConfigureAwait(false);
         }

--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -30,30 +30,28 @@ public class BackOffStrategy(TimeProvider timeProvider = null)
         DelayedMessageAvailable = true;
     }
 
-    public async Task WaitForNextExecution(CancellationToken cancellationToken = new())
+    public async Task WaitForNextExecution(CancellationToken cancellationToken = default)
     {
-        CalculateNextExecutionTime();
+        var now = timeProvider.GetUtcNow();
+        CalculateNextExecutionTime(now);
 
         // While running this loop, a new delayed message can be stored
         // and NextExecutionTime could be set to a new (sooner) time.
-        while (timeProvider.GetUtcNow() < NextExecutionTime)
+        while (now < NextExecutionTime)
         {
-            int waitTime = (int)(NextExecutionTime - timeProvider.GetUtcNow()).TotalMilliseconds;
-            waitTime = waitTime < 1000 ? waitTime : 1000;
-
-            if (waitTime > 0)
-            {
-                await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
-            }
+            var waitTime = NextExecutionTime - now;
+            waitTime = waitTime < oneSecond ? waitTime : oneSecond;
+            await Task.Delay(waitTime, timeProvider, cancellationToken).ConfigureAwait(false);
         }
+
         NextExecutionTime = DateTime.MaxValue;
     }
 
-    void CalculateNextExecutionTime()
+    void CalculateNextExecutionTime(DateTimeOffset now)
     {
         IncreaseExponentialBackOff();
 
-        var calculatedBackoffTime = timeProvider.GetUtcNow().AddMilliseconds(milliseconds);
+        var calculatedBackoffTime = now.AddMilliseconds(milliseconds);
 
         // If the next delayed message is coming up before the back-off time, use that.
         if (DelayedMessageAvailable && calculatedBackoffTime > NextDelayedMessage)
@@ -84,10 +82,12 @@ public class BackOffStrategy(TimeProvider timeProvider = null)
     const int InitialBackOffTime = 500;
 
     internal DateTime NextDelayedMessage { get; set; } = timeProvider.GetUtcNow().UtcDateTime;
-    internal DateTime NextExecutionTime { get; set; } = timeProvider.GetUtcNow().AddSeconds(2).UtcDateTime;
+    internal DateTime NextExecutionTime { get; set; } = timeProvider.GetUtcNow().UtcDateTime.AddSeconds(2);
     bool DelayedMessageAvailable { get; set; }
 
     int milliseconds = InitialBackOffTime; // First time multiplied will be 1 second.
     static readonly ILog Logger = LogManager.GetLogger<BackOffStrategy>();
+
     readonly TimeProvider timeProvider = timeProvider ?? TimeProvider.System;
+    readonly TimeSpan oneSecond = TimeSpan.FromSeconds(1);
 }

--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -1,11 +1,11 @@
-﻿namespace NServiceBus.Transport.Sql.Shared.DelayedDelivery;
+namespace NServiceBus.Transport.Sql.Shared.DelayedDelivery;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 
-class BackOffStrategy
+public class BackOffStrategy(TimeProvider timeProvider = null)
 {
     public void RegisterNewDueTime(DateTime dueTime)
     {
@@ -36,9 +36,9 @@ class BackOffStrategy
 
         // While running this loop, a new delayed message can be stored
         // and NextExecutionTime could be set to a new (sooner) time.
-        while (DateTime.UtcNow < NextExecutionTime)
+        while (timeProvider.GetUtcNow() < NextExecutionTime)
         {
-            int waitTime = (int)(NextExecutionTime - DateTime.UtcNow).TotalMilliseconds;
+            int waitTime = (int)(NextExecutionTime - timeProvider.GetUtcNow()).TotalMilliseconds;
             waitTime = waitTime < 1000 ? waitTime : 1000;
 
             if (waitTime > 0)
@@ -53,7 +53,7 @@ class BackOffStrategy
     {
         IncreaseExponentialBackOff();
 
-        var calculatedBackoffTime = DateTime.UtcNow.AddMilliseconds(milliseconds);
+        var calculatedBackoffTime = timeProvider.GetUtcNow().AddMilliseconds(milliseconds);
 
         // If the next delayed message is coming up before the back-off time, use that.
         if (DelayedMessageAvailable && calculatedBackoffTime > NextDelayedMessage)
@@ -67,8 +67,8 @@ class BackOffStrategy
         }
 
         Logger.Debug(
-            $"Exponentially backing off for {milliseconds / 1000} seconds until {calculatedBackoffTime}.");
-        NextExecutionTime = calculatedBackoffTime;
+            $"Exponentially backing off for {milliseconds / 1000} seconds until {calculatedBackoffTime.UtcDateTime}.");
+        NextExecutionTime = calculatedBackoffTime.UtcDateTime;
     }
 
     void IncreaseExponentialBackOff()
@@ -83,10 +83,11 @@ class BackOffStrategy
     const int MaximumDelayUntilNextPeek = 60000;
     const int InitialBackOffTime = 500;
 
-    internal DateTime NextDelayedMessage { get; set; } = DateTime.UtcNow;
-    internal DateTime NextExecutionTime { get; set; } = DateTime.UtcNow.AddSeconds(2);
+    internal DateTime NextDelayedMessage { get; set; } = timeProvider.GetUtcNow().UtcDateTime;
+    internal DateTime NextExecutionTime { get; set; } = timeProvider.GetUtcNow().AddSeconds(2).UtcDateTime;
     bool DelayedMessageAvailable { get; set; }
 
     int milliseconds = InitialBackOffTime; // First time multiplied will be 1 second.
     static readonly ILog Logger = LogManager.GetLogger<BackOffStrategy>();
+    readonly TimeProvider timeProvider = timeProvider ?? TimeProvider.System;
 }

--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -40,7 +40,11 @@ class BackOffStrategy
         {
             int waitTime = (int)(NextExecutionTime - DateTime.UtcNow).TotalMilliseconds;
             waitTime = waitTime < 1000 ? waitTime : 1000;
-            await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
+
+            if (waitTime > 0)
+            {
+                await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
+            }
         }
         NextExecutionTime = DateTime.MaxValue;
     }

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/NServiceBus.Transport.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/NServiceBus.Transport.SqlServer.UnitTests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus" Version="9.0.2" />
     <PackageReference Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
I stumbled upon a strange behavior regarding NSB and delayed messaged on SQL transport.
Sometimes delayed messages would not be processed anymore, without any exception or anything being logged. They just stay in the .Delayed table and are not moved to their target table anymore.
If they are moved there manually, the messages are processed normally.

In the logs I found occurrences of the following error: "The value needs to be either -1 (signifying an infinite timeout), 0 or a positive integer." in BackOffStrategy.WaitForNextExecution.
This shows, that sometimes negative values can be calculated. And in case of a -1, it would lead to an infinite wait time, which could explain my noticed behavior.

Unfortunately I was not able to write a stable test to reproduce this behavior.