### PR TITLE
Use SQL system catalog views to check for the presence of a Recoverable column

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlServerConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlServerConstants.cs
@@ -50,7 +50,11 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public string CheckIfTableHasRecoverableText { get; set; } = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
+        public string CheckIfTableHasRecoverableText { get; set; } = @"
+SELECT COUNT(*)
+FROM sys.columns c
+WHERE c.object_id = OBJECT_ID(N'{0}')
+    AND c.name = 'Recoverable'";
 
         public string StoreDelayedMessageText { get; set; } =
 @"


### PR DESCRIPTION
Use SQL system catalog views to check for the presence of a Recoverable column. This removes the need for SELECT permissions to send a message to a queue table.

Proposal to fix:

- #1196