### PR TITLE
SQL Server transport requires SELECT permission when sending to remote queues

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_configured_to_purge_expired_messages_at_startup.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_configured_to_purge_expired_messages_at_startup.cs
@@ -68,7 +68,7 @@
                 (address, isStreamSupported) =>
                 {
                     var canonicalAddress = addressTranslator.Parse(address);
-                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress.QualifiedTableName, canonicalAddress.Address, isStreamSupported);
+                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress, canonicalAddress.Address, isStreamSupported);
                 },
                 s => addressTranslator.Parse(s).Address,
                 true);

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
@@ -24,7 +24,7 @@
 
             await ResetQueue(addressParser, dbConnectionFactory);
 
-            queue = new SqlTableBasedQueue(sqlConstants, addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, false);
+            queue = new SqlTableBasedQueue(sqlConstants, addressParser.Parse(QueueTableName), QueueTableName, false);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
@@ -107,7 +107,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
                 (address, isStreamSupported) =>
                 {
                     var canonicalAddress = addressTranslator.Parse(address);
-                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress.QualifiedTableName, canonicalAddress.Address, isStreamSupported);
+                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress, canonicalAddress.Address, isStreamSupported);
                 },
                 s => addressTranslator.Parse(s).Address,
                 true);
@@ -122,7 +122,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
         Task PurgeOutputQueue(QueueAddressTranslator addressTranslator, CancellationToken cancellationToken = default)
         {
             purger = new QueuePurger(dbConnectionFactory);
-            var queueAddress = addressTranslator.Parse(ValidAddress).QualifiedTableName;
+            var queueAddress = addressTranslator.Parse(ValidAddress);
             queue = new SqlTableBasedQueue(sqlConstants, queueAddress, ValidAddress, true);
 
             return purger.Purge(queue, cancellationToken);

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -29,7 +29,7 @@
 
             await CreateQueueIfNotExists(addressParser, dbConnectionFactory);
 
-            queue = new SqlTableBasedQueue(sqlConstants, addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, true);
+            queue = new SqlTableBasedQueue(sqlConstants, addressParser.Parse(QueueTableName), QueueTableName, true);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
             transport.Testing.QueueFactoryOverride = qa =>
                 qa == inputQueueAddress
                     ? inputQueue
-                    : new SqlTableBasedQueue(sqlConstants, parser.Parse(qa).QualifiedTableName, qa, true);
+                    : new SqlTableBasedQueue(sqlConstants, parser.Parse(qa), qa, true);
 
             var receiveSettings = new ReceiveSettings("receiver", new Transport.QueueAddress(inputQueueName), true, false, "error");
             var hostSettings = new HostSettings("IntegrationTests", string.Empty, new StartupDiagnosticEntries(),
@@ -95,7 +95,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
             int queueSize;
             int successfulReceives;
 
-            public FakeTableBasedQueue(SqlServerConstants sqlConstants, string address, int queueSize, int successfulReceives) : base(sqlConstants, address, "", true)
+            public FakeTableBasedQueue(SqlServerConstants sqlConstants, string address, int queueSize, int successfulReceives) : base(sqlConstants, new QueueAddressTranslator("nservicebus", "dbo", null, new QueueSchemaAndCatalogOptions()).Parse(address), "", true)
             {
                 this.queueSize = queueSize;
                 this.successfulReceives = successfulReceives;

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Transport.SqlServer.IntegrationTests
                 (address, isStreamSupported) =>
                 {
                     var canonicalAddress = addressTranslator.Parse(address);
-                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress.QualifiedTableName, canonicalAddress.Address, isStreamSupported);
+                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress, canonicalAddress.Address, isStreamSupported);
                 },
                 s => addressTranslator.Parse(s).Address,
                 true);

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
@@ -127,7 +127,7 @@
                 (address, isStreamSupported) =>
                 {
                     var canonicalAddress = addressTranslator.Parse(address);
-                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress.QualifiedTableName, canonicalAddress.Address, isStreamSupported);
+                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress, canonicalAddress.Address, isStreamSupported);
                 },
                 s => addressTranslator.Parse(s).Address,
                 true);
@@ -147,7 +147,7 @@
         {
             purger = new QueuePurger(dbConnectionFactory);
             var queueAddress = addressParser.Parse(ValidAddress);
-            queue = new SqlTableBasedQueue(sqlConstants, queueAddress.QualifiedTableName, queueAddress.Address, true);
+            queue = new SqlTableBasedQueue(sqlConstants, queueAddress, queueAddress.Address, true);
 
             return purger.Purge(queue, cancellationToken);
         }

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/When_receive_takes_long_to_complete.cs
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/When_receive_takes_long_to_complete.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.TransportTests;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 using Transport;
 using Transport.SqlServer;
@@ -44,15 +45,15 @@ public class When_receive_takes_long_to_complete
         Assert.That(peekCount, Is.EqualTo(1), "A long running receive transaction should not skew the estimation for number of messages in the queue.");
     }
 
-    static async Task<SqlTableBasedQueue> CreateATestQueue(SqlServerDbConnectionFactory connectionFactory)
+    async Task<SqlTableBasedQueue> CreateATestQueue(SqlServerDbConnectionFactory connectionFactory)
     {
         var queueName = "queue_length_estimation_test";
 
         var sqlConstants = new SqlServerConstants();
 
-        var queue = new SqlTableBasedQueue(sqlConstants, queueName, queueName, false);
+        var queue = new SqlTableBasedQueue(sqlConstants, new CanonicalQueueAddress(queueName, "dbo", catalogName), queueName, false);
 
-        var addressTranslator = new QueueAddressTranslator("nservicebus", "dbo", null, null);
+        var addressTranslator = new QueueAddressTranslator(catalogName, "dbo", null, null);
         var queueCreator = new QueueCreator(sqlConstants, connectionFactory, addressTranslator.Parse, false);
 
         await queueCreator.CreateQueueIfNecessary(new[] { queueName }, null);
@@ -98,6 +99,11 @@ public class When_receive_takes_long_to_complete
     [SetUp]
     public async Task Setup()
     {
+        var connectionString = ConfigureSqlServerTransportInfrastructure.ConnectionString;
+        var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
+
+        catalogName = connectionStringBuilder.InitialCatalog;
+
         connectionFactory = new SqlServerDbConnectionFactory(ConfigureSqlServerTransportInfrastructure.ConnectionString);
 
         queue = await CreateATestQueue(connectionFactory);
@@ -119,6 +125,7 @@ public class When_receive_takes_long_to_complete
         await comm.ExecuteNonQueryAsync(CancellationToken.None);
     }
 
+    string catalogName;
     SqlTableBasedQueue queue;
     SqlServerDbConnectionFactory connectionFactory;
 }

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlServerConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlServerConstants.cs
@@ -50,7 +50,11 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public string CheckIfTableHasRecoverableText { get; set; } = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
+        public string CheckIfTableHasRecoverableText { get; set; } = @"
+SELECT COUNT(*)
+FROM {0}.sys.columns c
+WHERE c.object_id = OBJECT_ID(N'{1}')
+    AND c.name = 'Recoverable'";
 
         public string StoreDelayedMessageText { get; set; } =
 @"

--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Transport.SqlServer
                 (address, isStreamSupported) =>
                 {
                     var canonicalAddress = addressTranslator.Parse(address);
-                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress.QualifiedTableName, canonicalAddress.Address, isStreamSupported);
+                    return new SqlTableBasedQueue(sqlConstants, canonicalAddress, canonicalAddress.Address, isStreamSupported);
                 },
                 s => addressTranslator.Parse(s).Address,
                 !connectionAttributes.IsEncrypted);
@@ -161,7 +161,7 @@ namespace NServiceBus.Transport.SqlServer
 
             var schemaVerification = new SchemaInspector((queue, token) => connectionFactory.OpenNewConnection(token), validateExpiredIndex);
 
-            var queueFactory = transport.Testing.QueueFactoryOverride ?? (queueName => new SqlTableBasedQueue(sqlConstants, addressTranslator.Parse(queueName).QualifiedTableName, queueName, !connectionAttributes.IsEncrypted));
+            var queueFactory = transport.Testing.QueueFactoryOverride ?? (queueName => new SqlTableBasedQueue(sqlConstants, addressTranslator.Parse(queueName), queueName, !connectionAttributes.IsEncrypted));
 
             //Create delayed delivery infrastructure
             CanonicalQueueAddress delayedQueueCanonicalAddress = null;


### PR DESCRIPTION
Backport of #1442 which fixes #1196  for the `release-8.1` branch