### PR TITLE
SQL Server transport requires SELECT permission when sending to remote queues

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_configured_to_purge_expired_messages_at_startup.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativeTimeouts/When_configured_to_purge_expired_messages_at_startup.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.AcceptanceTests.NativeTimeouts
+namespace NServiceBus.Transport.SqlServer.AcceptanceTests.NativeTimeouts
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_checking_schema.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Threading;
@@ -23,7 +23,7 @@
 
             await ResetQueue(addressParser, sqlConnectionFactory);
 
-            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, false);
+            queue = new TableBasedQueue(addressParser.Parse(QueueTableName), QueueTableName, false);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_dispatching_messages.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -112,8 +112,7 @@
         Task PurgeOutputQueue(QueueAddressTranslator addressTranslator, CancellationToken cancellationToken = default)
         {
             purger = new QueuePurger(sqlConnectionFactory);
-            var queueAddress = addressTranslator.Parse(ValidAddress).QualifiedTableName;
-            queue = new TableBasedQueue(queueAddress, ValidAddress, true);
+            queue = new TableBasedQueue(addressTranslator.Parse(ValidAddress), ValidAddress, true);
 
             return purger.Purge(queue, cancellationToken);
         }

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_message_receive_takes_long.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -28,7 +28,7 @@
 
             await CreateQueueIfNotExists(addressParser, sqlConnectionFactory);
 
-            queue = new TableBasedQueue(addressParser.Parse(QueueTableName).QualifiedTableName, QueueTableName, true);
+            queue = new TableBasedQueue(addressParser.Parse(QueueTableName), QueueTableName, true);
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_receiving_messages.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Linq;
@@ -23,7 +23,7 @@
 
             var parser = new QueueAddressTranslator("nservicebus", "dbo", null, null);
             var inputQueueName = "input";
-            var inputQueueAddress = parser.Parse(inputQueueName).Address;
+            var inputQueueAddress = parser.Parse(inputQueueName);
             var inputQueue = new FakeTableBasedQueue(inputQueueAddress, queueSize, successfulReceives);
 
             var connectionString = Environment.GetEnvironmentVariable("SqlServerTransportConnectionString") ?? @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True";
@@ -35,7 +35,7 @@
             };
 
             transport.Testing.QueueFactoryOverride = qa =>
-                qa == inputQueueAddress ? inputQueue : new TableBasedQueue(parser.Parse(qa).QualifiedTableName, qa, true);
+                qa == inputQueueAddress.Address ? inputQueue : new TableBasedQueue(parser.Parse(qa), qa, true);
 
             var receiveSettings = new ReceiveSettings("receiver", new Transport.QueueAddress(inputQueueName), true, false, "error");
             var hostSettings = new HostSettings("IntegrationTests", string.Empty, new StartupDiagnosticEntries(),
@@ -87,7 +87,7 @@
             int queueSize;
             int successfulReceives;
 
-            public FakeTableBasedQueue(string address, int queueSize, int successfulReceives) : base(address, "", true)
+            public FakeTableBasedQueue(CanonicalQueueAddress address, int queueSize, int successfulReceives) : base(address, "", true)
             {
                 this.queueSize = queueSize;
                 this.successfulReceives = successfulReceives;

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_recoverable_column_is_removed.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/When_using_ttbr.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SqlServer.IntegrationTests
+namespace NServiceBus.Transport.SqlServer.IntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -134,7 +134,7 @@
         {
             purger = new QueuePurger(sqlConnectionFactory);
             var queueAddress = addressParser.Parse(ValidAddress);
-            queue = new TableBasedQueue(queueAddress.QualifiedTableName, queueAddress.Address, true);
+            queue = new TableBasedQueue(queueAddress, queueAddress.Address, true);
 
             return purger.Purge(queue, cancellationToken);
         }

--- a/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/SqlConstants.cs
@@ -48,7 +48,11 @@ VALUES (
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
-        public static readonly string CheckIfTableHasRecoverableText = "SELECT TOP (0) * FROM {0} WITH (NOLOCK);";
+        public static string CheckIfTableHasRecoverableText { get; set; } = @"
+SELECT COUNT(*)
+FROM {0}.sys.columns c
+WHERE c.object_id = OBJECT_ID(N'{1}')
+    AND c.name = 'Recoverable'";
 
         public static readonly string StoreDelayedMessageText =
 @"

--- a/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueueCache.cs
+++ b/src/NServiceBus.Transport.SqlServer/Queuing/TableBasedQueueCache.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Transport.SqlServer
         {
             var address = addressTranslator.Parse(destination);
             var key = Tuple.Create(address.QualifiedTableName, address.Address);
-            var queue = cache.GetOrAdd(key, x => new TableBasedQueue(x.Item1, x.Item2, isStreamSupported));
+            var queue = cache.GetOrAdd(key, x => new TableBasedQueue(address, x.Item2, isStreamSupported));
 
             return queue;
         }

--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
@@ -131,7 +131,7 @@ namespace NServiceBus.Transport.SqlServer
 
             var schemaVerification = new SchemaInspector((queue, token) => connectionFactory.OpenNewConnection(token), validateExpiredIndex);
 
-            var queueFactory = transport.Testing.QueueFactoryOverride ?? (queueName => new TableBasedQueue(addressTranslator.Parse(queueName).QualifiedTableName, queueName, !isEncrypted));
+            var queueFactory = transport.Testing.QueueFactoryOverride ?? (queueName => new TableBasedQueue(addressTranslator.Parse(queueName), queueName, !isEncrypted));
 
             //Create delayed delivery infrastructure
             CanonicalQueueAddress delayedQueueCanonicalAddress = null;


### PR DESCRIPTION
Backport of #1442 which fixes #1196  for the `release-7.0` branch