### PR TITLE
Stop pumps on shutdown

### DIFF
--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
@@ -342,11 +342,16 @@ namespace NServiceBus.Transport.SqlServer
                 connectionFactory);
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken = default)
+        public override async Task Shutdown(CancellationToken cancellationToken = default)
         {
-            return dueDelayedMessageProcessor?.Stop(cancellationToken) ?? Task.FromResult(0);
-        }
+            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
 
+            if (dueDelayedMessageProcessor != null)
+            {
+                await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+            }
+        }
 
         readonly SqlServerTransport transport;
         readonly HostSettings hostSettings;


### PR DESCRIPTION
This aligns the transport to stop the pumps on transport shutdown and at the same time makes sure the pumps stop method can be called multiple times. 

This is part of addressing some low-hanging fruit to align all transports for the transport seam usage scenarios to make sure pumps are stopped when the transport shuts down. 

I have tried to write a transport test for it to enforce it eventually for all transport but couldn't find a way to do that without introducing flags on the transport interface and using fancy techniques like default members which seams overkill