### PR TITLE
Make receiver concurrency lock object private and non static

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/MessageReceiver.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/MessageReceiver.cs
@@ -261,7 +261,7 @@ namespace NServiceBus.Transport.Sql.Shared
 
         protected TableBasedQueue inputQueue;
         TableBasedQueue errorQueue;
-        readonly object lockObject = new(); // Not static, must not be shared between receiver instances
+        readonly object lockObject = new();
         readonly TransportDefinition transport;
         readonly string errorQueueAddress;
         readonly Action<string, Exception, CancellationToken> criticalErrorAction;

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/MessageReceiver.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/MessageReceiver.cs
@@ -261,6 +261,7 @@ namespace NServiceBus.Transport.Sql.Shared
 
         protected TableBasedQueue inputQueue;
         TableBasedQueue errorQueue;
+        readonly object lockObject = new(); // Not static, must not be shared between receiver instances
         readonly TransportDefinition transport;
         readonly string errorQueueAddress;
         readonly Action<string, Exception, CancellationToken> criticalErrorAction;
@@ -287,7 +288,5 @@ namespace NServiceBus.Transport.Sql.Shared
         public ISubscriptionManager Subscriptions { get; }
         public string Id { get; }
         public string ReceiveAddress { get; }
-
-        public static object lockObject = new();
     }
 }


### PR DESCRIPTION
Resolves that the lock object introduced in the following PR isn't static and no longer public:

- https://github.com/Particular/NServiceBus.SqlServer/pull/1534

Approvals didn't need updating because the class itself is private.