### PR TITLE
Avoid cancellation token cross-contamination and thundering herd in subscription cache

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/PostgreSqlTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.PostgreSql/PostgreSqlTransportInfrastructure.cs
@@ -47,12 +47,19 @@ class PostgreSqlTransportInfrastructure : TransportInfrastructure
 
     public override async Task Shutdown(CancellationToken cancellationToken = default)
     {
-        await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
-            .ConfigureAwait(false);
-
-        if (dueDelayedMessageProcessor != null)
+        try
         {
-            await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
+
+            if (dueDelayedMessageProcessor != null)
+            {
+                await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            (subscriptionStore as IDisposable)?.Dispose();
         }
     }
 

--- a/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
@@ -7,14 +7,8 @@ namespace NServiceBus.Transport.Sql.Shared
     using System.Threading.Tasks;
 
 
-    class CachedSubscriptionStore : ISubscriptionStore
+    class CachedSubscriptionStore(ISubscriptionStore inner, TimeSpan cacheFor) : ISubscriptionStore
     {
-        public CachedSubscriptionStore(ISubscriptionStore inner, TimeSpan cacheFor)
-        {
-            this.inner = inner;
-            this.cacheFor = cacheFor;
-        }
-
         public Task<List<string>> GetSubscribers(Type eventType, CancellationToken cancellationToken = default)
         {
             var cacheItem = Cache.GetOrAdd(CacheKey(eventType),
@@ -56,8 +50,6 @@ namespace NServiceBus.Transport.Sql.Shared
             return eventType.FullName;
         }
 
-        TimeSpan cacheFor;
-        ISubscriptionStore inner;
         ConcurrentDictionary<string, CacheItem> Cache = new ConcurrentDictionary<string, CacheItem>();
 
         class CacheItem

--- a/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
@@ -103,16 +103,9 @@ namespace NServiceBus.Transport.Sql.Shared
             public async ValueTask Clear()
 #pragma warning restore PS0018
             {
-                await fetchSemaphore.WaitAsync().ConfigureAwait(false);
-                try
-                {
-                    cachedSubscriptions = null;
-                    cachedAtTimestamp = 0;
-                }
-                finally
-                {
-                    fetchSemaphore.Release();
-                }
+                using var lease = await AcquireLease(CancellationToken.None).ConfigureAwait(false);
+                cachedSubscriptions = null;
+                cachedAtTimestamp = 0;
             }
 
             public void Dispose() => fetchSemaphore.Dispose();

--- a/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
@@ -86,7 +86,7 @@ namespace NServiceBus.Transport.Sql.Shared
                     return cachedSubscriptionsSnapshot;
                 }
 
-                await fetchSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                await fetchSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 try
                 {

--- a/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
@@ -119,7 +119,7 @@ namespace NServiceBus.Transport.Sql.Shared
                 }
                 finally
                 {
-                    fetchSemaphore.Release():
+                    fetchSemaphore.Release();
                 }
             }
 

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/CachedSubscriptionStoreTests.cs
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/CachedSubscriptionStoreTests.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.Transport.SqlServer.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sql.Shared;
+
+[TestFixture]
+public class CachedSubscriptionStoreTests
+{
+    // Reproduces a bug that previously existed in the original implementation that stored tasks and their outcomes in the cache (see #1588)
+    // leaving this test around to make sure such a problem doesn't occur again.
+    [Test]
+    public void Should_not_cache_cancelled_operations()
+    {
+        var subscriptionStore = new FakeSubscriptionStore
+        {
+            GetSubscribersAction = (_, token) => token.IsCancellationRequested ? Task.FromCanceled<List<string>>(token) : Task.FromResult(new List<string>())
+        };
+
+        var cache = new CachedSubscriptionStore(subscriptionStore, TimeSpan.FromSeconds(60));
+
+        Assert.Multiple(() =>
+        {
+            _ = Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await cache.GetSubscribers(typeof(object), new CancellationToken(true)));
+            Assert.DoesNotThrowAsync(async () => await cache.GetSubscribers(typeof(object), CancellationToken.None));
+        });
+    }
+
+    class FakeSubscriptionStore : ISubscriptionStore
+    {
+        public Func<Type, CancellationToken, Task<List<string>>> GetSubscribersAction { get; set; } =
+            (_, _) => Task.FromResult(new List<string>());
+
+        public Task<List<string>> GetSubscribers(Type eventType, CancellationToken cancellationToken = default) =>
+            GetSubscribersAction(eventType, cancellationToken);
+
+        public Task Subscribe(string endpointName, string endpointAddress, Type eventType,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task Unsubscribe(string endpointName, Type eventType, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
@@ -337,12 +337,19 @@ namespace NServiceBus.Transport.SqlServer
 
         public override async Task Shutdown(CancellationToken cancellationToken = default)
         {
-            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
-                .ConfigureAwait(false);
-
-            if (dueDelayedMessageProcessor != null)
+            try
             {
-                await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+                await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                    .ConfigureAwait(false);
+
+                if (dueDelayedMessageProcessor != null)
+                {
+                    await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                (subscriptionStore as IDisposable)?.Dispose();
             }
         }
 


### PR DESCRIPTION
Fixes #1588 

- Fixed cancellation coupling: Previously cached Task<List> could carry a caller’s CancellationToken, causing unintended cancellations for later callers. Now the cache stores the result so each caller’s token is handled independently during fetch.
- Preserved cache behavior: Expiration and invalidation on Subscribe/Unsubscribe are unchanged.
- Thundering herd mitigation: A SemaphoreSlim serializes refreshes so only one fetch occurs per event type when the cache is empty/expired, reducing concurrent connections and avoiding pool exhaustion.
- Deterministic invalidation: Clear runs without flowing caller cancellation to ensure cache is always invalidated after updates.
- Stable timing: Cache freshness uses Stopwatch-based elapsed time, avoiding issues from system clock adjustments.
- Graceful shutdown: Cached entries’ synchronization primitives are disposed at endpoint shutdown.
