### PR TITLE
Avoid cancellation token cross-contamination and thundering herd in subscription cache

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/PostgreSqlTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.PostgreSql/PostgreSqlTransportInfrastructure.cs
@@ -45,9 +45,22 @@ class PostgreSqlTransportInfrastructure : TransportInfrastructure
         exceptionClassifier = new PostgreSqlExceptionClassifier();
     }
 
-    public override Task Shutdown(CancellationToken cancellationToken = default)
+    public override async Task Shutdown(CancellationToken cancellationToken = default)
     {
-        return dueDelayedMessageProcessor?.Stop(cancellationToken) ?? Task.FromResult(0);
+        try
+        {
+            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
+
+            if (dueDelayedMessageProcessor != null)
+            {
+                await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            (subscriptionStore as IDisposable)?.Dispose();
+        }
     }
 
     public override string ToTransportAddress(Transport.QueueAddress address)

--- a/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/PubSub/CachedSubscriptionStore.cs
@@ -3,67 +3,127 @@ namespace NServiceBus.Transport.Sql.Shared
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
 
-    class CachedSubscriptionStore : ISubscriptionStore
+    sealed class CachedSubscriptionStore(ISubscriptionStore inner, TimeSpan cacheFor) : ISubscriptionStore, IDisposable
     {
-        public CachedSubscriptionStore(ISubscriptionStore inner, TimeSpan cacheFor)
+        public async Task<List<string>> GetSubscribers(Type eventType, CancellationToken cancellationToken = default)
         {
-            this.inner = inner;
-            this.cacheFor = cacheFor;
-        }
+            var cacheKey = CacheKey(eventType);
+            var cachedSubscriptions = Cache.GetOrAdd(cacheKey,
+                static (_, state) => new CachedSubscriptions(state.inner, state.eventType, state.cacheFor),
+                (inner, eventType, cacheFor));
 
-        public Task<List<string>> GetSubscribers(Type eventType, CancellationToken cancellationToken = default)
-        {
-            var cacheItem = Cache.GetOrAdd(CacheKey(eventType),
-                _ => new CacheItem
-                {
-                    StoredUtc = DateTime.UtcNow,
-                    Subscribers = inner.GetSubscribers(eventType, cancellationToken)
-                });
-
-            var age = DateTime.UtcNow - cacheItem.StoredUtc;
-            if (age >= cacheFor)
-            {
-                cacheItem.Subscribers = inner.GetSubscribers(eventType, cancellationToken);
-                cacheItem.StoredUtc = DateTime.UtcNow;
-            }
-
-            return cacheItem.Subscribers;
+            return await cachedSubscriptions.EnsureFresh(cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Subscribe(string endpointName, string endpointAddress, Type eventType, CancellationToken cancellationToken = default)
         {
-            await inner.Subscribe(endpointName, endpointAddress, eventType, cancellationToken).ConfigureAwait(false);
-            ClearForMessageType(CacheKey(eventType));
+            try
+            {
+                await inner.Subscribe(endpointName, endpointAddress, eventType, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await Clear(CacheKey(eventType))
+                    .ConfigureAwait(false);
+            }
         }
 
         public async Task Unsubscribe(string endpointName, Type eventType, CancellationToken cancellationToken = default)
         {
-            await inner.Unsubscribe(endpointName, eventType, cancellationToken).ConfigureAwait(false);
-            ClearForMessageType(CacheKey(eventType));
+            try
+            {
+                await inner.Unsubscribe(endpointName, eventType, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await Clear(CacheKey(eventType))
+                    .ConfigureAwait(false);
+            }
         }
 
-        void ClearForMessageType(string topic)
+        public void Dispose()
         {
-            Cache.TryRemove(topic, out _);
+            if (Cache.IsEmpty)
+            {
+                return;
+            }
+
+            foreach (var subscription in Cache.Values)
+            {
+                subscription.Dispose();
+            }
+
+            Cache.Clear();
         }
 
-        static string CacheKey(Type eventType)
-        {
-            return eventType.FullName;
-        }
+#pragma warning disable PS0018 // Clear should not be cancellable
+        ValueTask Clear(string cacheKey) => Cache.TryGetValue(cacheKey, out var cachedSubscriptions) ? cachedSubscriptions.Clear() : ValueTask.CompletedTask;
+#pragma warning restore PS0018
 
-        TimeSpan cacheFor;
-        ISubscriptionStore inner;
-        ConcurrentDictionary<string, CacheItem> Cache = new ConcurrentDictionary<string, CacheItem>();
+        static string CacheKey(Type eventType) => eventType.FullName;
 
-        class CacheItem
+        readonly ConcurrentDictionary<string, CachedSubscriptions> Cache = new();
+
+        sealed class CachedSubscriptions(ISubscriptionStore store, Type eventType, TimeSpan cacheFor) : IDisposable
         {
-            public DateTime StoredUtc { get; set; } // Internal usage, only set/get using private
-            public Task<List<string>> Subscribers { get; set; }
+            readonly SemaphoreSlim fetchSemaphore = new(1, 1);
+
+            List<string> cachedSubscriptions;
+            long cachedAtTimestamp;
+
+            public async ValueTask<List<string>> EnsureFresh(CancellationToken cancellationToken = default)
+            {
+                var cachedSubscriptionsSnapshot = cachedSubscriptions;
+                var cachedAtTimestampSnapshot = cachedAtTimestamp;
+
+                if (cachedSubscriptionsSnapshot != null && Stopwatch.GetElapsedTime(cachedAtTimestampSnapshot) < cacheFor)
+                {
+                    return cachedSubscriptionsSnapshot;
+                }
+
+                await fetchSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    if (cachedSubscriptions != null && Stopwatch.GetElapsedTime(cachedAtTimestamp) < cacheFor)
+                    {
+                        return cachedSubscriptions;
+                    }
+
+                    cachedSubscriptions = await store.GetSubscribers(eventType, cancellationToken).ConfigureAwait(false);
+                    cachedAtTimestamp = Stopwatch.GetTimestamp();
+
+                    return cachedSubscriptions;
+                }
+                finally
+                {
+                    fetchSemaphore.Release();
+                }
+            }
+
+#pragma warning disable PS0018 // Clear should not be cancellable
+            public async ValueTask Clear()
+#pragma warning restore PS0018
+            {
+                try
+                {
+                    await fetchSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+
+                    cachedSubscriptions = null;
+                    cachedAtTimestamp = 0;
+                }
+                finally
+                {
+                    fetchSemaphore.Release();
+                }
+            }
+
+            public void Dispose() => fetchSemaphore.Dispose();
         }
     }
 }

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/CachedSubscriptionStoreTests.cs
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/CachedSubscriptionStoreTests.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.Transport.SqlServer.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sql.Shared;
+
+[TestFixture]
+public class CachedSubscriptionStoreTests
+{
+    // Reproduces a bug that previously existed in the original implementation that stored tasks and their outcomes in the cache (see #1588)
+    // leaving this test around to make sure such a problem doesn't occur again.
+    [Test]
+    public void Should_not_cache_cancelled_operations()
+    {
+        var subscriptionStore = new FakeSubscriptionStore
+        {
+            GetSubscribersAction = (_, token) => token.IsCancellationRequested ? Task.FromCanceled<List<string>>(token) : Task.FromResult(new List<string>())
+        };
+
+        var cache = new CachedSubscriptionStore(subscriptionStore, TimeSpan.FromSeconds(60));
+
+        Assert.Multiple(() =>
+        {
+            _ = Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await cache.GetSubscribers(typeof(object), new CancellationToken(true)));
+            Assert.DoesNotThrowAsync(async () => await cache.GetSubscribers(typeof(object), CancellationToken.None));
+        });
+    }
+
+    class FakeSubscriptionStore : ISubscriptionStore
+    {
+        public Func<Type, CancellationToken, Task<List<string>>> GetSubscribersAction { get; set; } =
+            (_, _) => Task.FromResult(new List<string>());
+
+        public Task<List<string>> GetSubscribers(Type eventType, CancellationToken cancellationToken = default) =>
+            GetSubscribersAction(eventType, cancellationToken);
+
+        public Task Subscribe(string endpointName, string endpointAddress, Type eventType,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task Unsubscribe(string endpointName, Type eventType, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs
@@ -335,9 +335,22 @@ namespace NServiceBus.Transport.SqlServer
                 connectionFactory);
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken = default)
+        public override async Task Shutdown(CancellationToken cancellationToken = default)
         {
-            return dueDelayedMessageProcessor?.Stop(cancellationToken) ?? Task.FromResult(0);
+            try
+            {
+                await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                    .ConfigureAwait(false);
+
+                if (dueDelayedMessageProcessor != null)
+                {
+                    await dueDelayedMessageProcessor.Stop(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                (subscriptionStore as IDisposable)?.Dispose();
+            }
         }
 
 


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.SqlServer/pull/1587 to `release-8.1`