### PR TITLE
Optimize peeks

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/AsyncCountdownLatch.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/AsyncCountdownLatch.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus.Transport.Sql.Shared;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+class AsyncCountdownLatch
+{
+    int count;
+    readonly TaskCompletionSource completionSource;
+
+    public AsyncCountdownLatch(int count)
+    {
+        this.count = count;
+        completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (count <= 0)
+        {
+            completionSource.SetResult();
+        }
+    }
+
+    public Task WaitAsync() => completionSource.Task;
+
+    public void Signal()
+    {
+        if (Interlocked.Decrement(ref count) == 0)
+        {
+            completionSource.SetResult();
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessStrategy.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport.Sql.Shared
         }
 
         public abstract Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource,
-            CountdownEvent receiveCompletion, CancellationToken cancellationToken = default);
+            AsyncCountdownLatch receiveLatch, CancellationToken cancellationToken = default);
 
         protected async Task<bool> TryHandleMessage(Message message, TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNativeTransaction.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNativeTransaction.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Transport.Sql.Shared
         }
 
         public override async Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource,
-            CountdownEvent receiveCompletion, CancellationToken cancellationToken = default)
+            AsyncCountdownLatch receiveLatch, CancellationToken cancellationToken = default)
         {
             Message message = null;
             var context = new ContextBag();
@@ -40,7 +40,7 @@ namespace NServiceBus.Transport.Sql.Shared
                     }
                     finally
                     {
-                        receiveCompletion.Signal();
+                        receiveLatch.Signal();
                     }
 
                     if (receiveResult == MessageReadResult.NoMessage)

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNoTransaction.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNoTransaction.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Transport.Sql.Shared
         }
 
         public override async Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource,
-            CountdownEvent receiveCompletion, CancellationToken cancellationToken = default)
+            AsyncCountdownLatch receiveLatch, CancellationToken cancellationToken = default)
         {
             Message message = null;
             var context = new ContextBag();
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport.Sql.Shared
                         }
                         finally
                         {
-                            receiveCompletion.Signal();
+                            receiveLatch.Signal();
                         }
 
                         if (receiveResult == MessageReadResult.NoMessage)

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithTransactionScope.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithTransactionScope.cs
@@ -18,7 +18,7 @@
         }
 
         public override async Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource,
-            CountdownEvent receiveCompletion, CancellationToken cancellationToken = default)
+            AsyncCountdownLatch receiveLatch, CancellationToken cancellationToken = default)
         {
             Message message = null;
             var context = new ContextBag();
@@ -35,7 +35,7 @@
                     }
                     finally
                     {
-                        receiveCompletion.Signal();
+                        receiveLatch.Signal();
                     }
 
                     if (receiveResult == MessageReadResult.NoMessage)


### PR DESCRIPTION
# Description

Fixes:

- #1614

This reduces the number of times the transport will run the "receive" query unnecessarily by ensuring that messages in the current "peek" batch have all at least locked the message row (via the "receive") query before doing another peek operation.

In the case of a single physical endpoint, this completely eliminates redundant reads.

In the case of multiple physical endpoints, there will still be redundant reads due to competing consumers, but this is still a significant improvement.

## Results

In testing on real-world systems, we have 300% unnecessary additional "receive" calls when the queue was empty, or all other messages were being processed. This PR makes that 0.

On a synthetic test we did, with multiple physical endpoints, each endpoint saw a similar reduction in this overrun.

## Approach

A new concept `AsyncCountdownLatch` has been added, which is similar to a `CountdownEvent` but works with async.

The message receiver creates one of these for each peek batch, with a count equal to the batch size, and passes it down to the `ProcessStrategy` being used.

The strategy will signal this latch when its receive query has been completed, and the latch will be released when all have been completed.

There is an edge case accounted for when the processing is cancelled - in this case, we want to ignore the latch, and exit the method anyway.

## Quality

All existing integration and unit tests still pass.  None extra have been written, I'm open to guidance from Particular on this.