### PR TITLE
Moved the latch signal up the stack

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNativeTransaction.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithNativeTransaction.cs
@@ -26,6 +26,7 @@ namespace NServiceBus.Transport.Sql.Shared
         {
             Message message = null;
             var context = new ContextBag();
+            var hasLatchBeenSignalled = false;
 
             try
             {
@@ -41,6 +42,7 @@ namespace NServiceBus.Transport.Sql.Shared
                     finally
                     {
                         receiveLatch.Signal();
+                        hasLatchBeenSignalled = true;
                     }
 
                     if (receiveResult == MessageReadResult.NoMessage)
@@ -86,6 +88,13 @@ namespace NServiceBus.Transport.Sql.Shared
                     throw;
                 }
                 failureInfoStorage.RecordFailureInfoForMessage(message.TransportId, ex, context);
+            }
+            finally
+            {
+                if (!hasLatchBeenSignalled)
+                {
+                    receiveLatch.Signal();
+                }
             }
         }
 

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithTransactionScope.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessWithTransactionScope.cs
@@ -22,6 +22,7 @@
         {
             Message message = null;
             var context = new ContextBag();
+            var hasLatchBeenSignalled = false;
 
             try
             {
@@ -36,6 +37,7 @@
                     finally
                     {
                         receiveLatch.Signal();
+                        hasLatchBeenSignalled = true;
                     }
 
                     if (receiveResult == MessageReadResult.NoMessage)
@@ -78,6 +80,13 @@
                     throw;
                 }
                 failureInfoStorage.RecordFailureInfoForMessage(message.TransportId, ex, context);
+            }
+            finally
+            {
+                if (!hasLatchBeenSignalled)
+                {
+                    receiveLatch.Signal();
+                }
             }
         }
 


### PR DESCRIPTION
Ensures the latch is signalled in cases where the connection setup fails.

Also has a guard in place to ensure it doesn't get signalled twice when it doesn't fail.

Relates to #1614 