### PR TITLE
[Backport to 8.1] Optimize peeks by replacing synchronous countdown event with an async countdown latch based on TCS

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/FailureInfoStorage.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/FailureInfoStorage.cs
@@ -3,17 +3,12 @@
     using System;
     using System.Collections.Generic;
     using System.Runtime.ExceptionServices;
-    using NServiceBus.Extensibility;
+    using Extensibility;
 
     // The data structure has fixed maximum size. When the data structure reaches its maximum size,
     // the least recently used (LRU) message processing failure is removed from the storage.
-    class FailureInfoStorage
+    class FailureInfoStorage(int maxElements)
     {
-        public FailureInfoStorage(int maxElements)
-        {
-            this.maxElements = maxElements;
-        }
-
         public void RecordFailureInfoForMessage(string messageId, Exception exception, ContextBag context)
         {
             lock (lockObject)
@@ -75,8 +70,6 @@
         Dictionary<string, FailureInfoNode> failureInfoPerMessage = [];
         LinkedList<string> leastRecentlyUsedMessages = new LinkedList<string>();
         object lockObject = new object();
-
-        int maxElements;
 
         class FailureInfoNode
         {

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ProcessStrategy.cs
@@ -5,8 +5,8 @@ namespace NServiceBus.Transport.Sql.Shared
     using System.Threading;
     using System.Threading.Tasks;
     using Faults;
-    using NServiceBus.Extensibility;
-    using NServiceBus.Logging;
+    using Extensibility;
+    using Logging;
     using Unicast.Queuing;
 
     abstract class ProcessStrategy
@@ -35,7 +35,8 @@ namespace NServiceBus.Transport.Sql.Shared
             this.criticalError = criticalError;
         }
 
-        public abstract Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource, CancellationToken cancellationToken = default);
+        public abstract Task ProcessMessage(CancellationTokenSource stopBatchCancellationTokenSource,
+            ReceiveCountdownEvent.Signaler receiveCountdownEventSignaler, CancellationToken cancellationToken = default);
 
         protected async Task<bool> TryHandleMessage(Message message, TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/QueuePeeker.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/QueuePeeker.cs
@@ -6,15 +6,8 @@
     using System.Transactions;
     using Logging;
 
-    class QueuePeeker : IPeekMessagesInQueue
+    class QueuePeeker(DbConnectionFactory connectionFactory, IExceptionClassifier exceptionClassifier, TimeSpan peekDelay) : IPeekMessagesInQueue
     {
-        public QueuePeeker(DbConnectionFactory connectionFactory, IExceptionClassifier exceptionClassifier, TimeSpan peekDelay)
-        {
-            this.connectionFactory = connectionFactory;
-            this.exceptionClassifier = exceptionClassifier;
-            this.peekDelay = peekDelay;
-        }
-
         public async Task<int> Peek(TableBasedQueue inputQueue, RepeatedFailuresOverTimeCircuitBreaker circuitBreaker, CancellationToken cancellationToken = default)
         {
             var messageCount = 0;
@@ -49,10 +42,6 @@
 
             return messageCount;
         }
-
-        readonly DbConnectionFactory connectionFactory;
-        readonly IExceptionClassifier exceptionClassifier;
-        readonly TimeSpan peekDelay;
 
         static readonly ILog Logger = LogManager.GetLogger<QueuePeeker>();
     }

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/QueuePurger.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/QueuePurger.cs
@@ -3,13 +3,8 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    class QueuePurger : IPurgeQueues
+    class QueuePurger(DbConnectionFactory connectionFactory) : IPurgeQueues
     {
-        public QueuePurger(DbConnectionFactory connectionFactory)
-        {
-            this.connectionFactory = connectionFactory;
-        }
-
         public virtual async Task<int> Purge(TableBasedQueue queue, CancellationToken cancellationToken = default)
         {
             using (var connection = await connectionFactory.OpenNewConnection(cancellationToken).ConfigureAwait(false))
@@ -17,7 +12,5 @@
                 return await queue.Purge(connection, cancellationToken).ConfigureAwait(false);
             }
         }
-
-        DbConnectionFactory connectionFactory;
     }
 }

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.Transport.Sql.Shared;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ReceiveCountdownEvent
+{
+    int count;
+    readonly TaskCompletionSource completionSource;
+
+    public ReceiveCountdownEvent(int count)
+    {
+        this.count = count;
+        completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (count <= 0)
+        {
+            completionSource.SetResult();
+        }
+    }
+
+    public async Task WaitAsync(CancellationToken cancellationToken = default)
+    {
+        var registration = cancellationToken.Register(static state => ((TaskCompletionSource)state).TrySetResult(), completionSource);
+        await using var _ = registration.ConfigureAwait(false);
+        await completionSource.Task.ConfigureAwait(false);
+    }
+
+    public Signaler GetSignaler() => new(this);
+
+    void Signal()
+    {
+        if (Interlocked.Decrement(ref count) == 0)
+        {
+            _ = completionSource.TrySetResult();
+        }
+    }
+
+    public struct Signaler(ReceiveCountdownEvent parent) : IDisposable
+    {
+        bool signalled;
+
+        public void Signal()
+        {
+            if (signalled)
+            {
+                return;
+            }
+
+            parent.Signal();
+            signalled = true;
+        }
+
+        public void Dispose()
+        {
+            if (signalled)
+            {
+                return;
+            }
+
+            parent.Signal();
+            signalled = true;
+        }
+    }
+}


### PR DESCRIPTION
Backport of:

- #1627

to `release-8.1`