### PR TITLE
Handle concurrent table creation errors

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
@@ -59,10 +59,11 @@ namespace NServiceBus.Transport.PostgreSql
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
             }
-            catch (PostgresException ex) when (ex.SqlState is "23505" or "42P07")
+            catch (PostgresException ex) when (ex.SqlState is PostgresErrorCodes.DuplicateTable or  // 42P07
+                PostgresErrorCodes.DuplicateObject or  // 42710
+                PostgresErrorCodes.UniqueViolation)    // 23505
             {
-                //PostgreSQL error code 23505: unique_violation or 42P07: relation already exists, is returned
-                //if the table creation is executed concurrently by multiple transactions
+                //This happens if the table creation is executed concurrently by multiple transactions
                 //In this case we want to discard the exception and continue
                 Logger.Debug($"{canonicalQueueAddress} already exists.", ex);
             }

--- a/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
@@ -7,11 +7,14 @@ namespace NServiceBus.Transport.PostgreSql
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Logging;
     using Npgsql;
     using NServiceBus.Transport.Sql.Shared;
 
     class QueueCreator
     {
+        static ILog Logger = LogManager.GetLogger<QueueCreator>();
+
         public QueueCreator(ISqlConstants sqlConstants, DbConnectionFactory connectionFactory, Func<string, CanonicalQueueAddress> addressTranslator, bool createMessageBodyColumn = false)
         {
             this.sqlConstants = sqlConstants;
@@ -56,11 +59,12 @@ namespace NServiceBus.Transport.PostgreSql
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
             }
-            catch (PostgresException ex) when (ex.SqlState == "23505")
+            catch (PostgresException ex) when (ex.SqlState is "23505" or "42P07")
             {
-                //PostgreSQL error code 23505: unique_violation is returned
+                //PostgreSQL error code 23505: unique_violation or 42P07: relation already exists, is returned
                 //if the table creation is executed concurrently by multiple transactions
                 //In this case we want to discard the exception and continue
+                Logger.Debug($"{canonicalQueueAddress} already exists.", ex);
             }
 
             if (createMessageBodyColumn)

--- a/src/NServiceBus.Transport.PostgreSql/SubscriptionTableCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/SubscriptionTableCreator.cs
@@ -43,9 +43,9 @@ namespace NServiceBus.Transport.PostgreSql
                         transaction.Commit();
                     }
                 }
-                catch (PostgresException ex) when (ex.SqlState == "23505")
+                catch (PostgresException ex) when (ex.SqlState is "23505" or "42P07")
                 {
-                    //PostgreSQL error code 23505: unique_violation is returned
+                    //PostgreSQL error code 23505: unique_violation or 42P07: relation already exists, is returned
                     //if the table creation is executed concurrently by multiple transactions
                     //In this case we want to discard the exception and continue
                     Logger.Debug("Subscription Table already exists.", ex);

--- a/src/NServiceBus.Transport.PostgreSql/SubscriptionTableCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/SubscriptionTableCreator.cs
@@ -43,10 +43,11 @@ namespace NServiceBus.Transport.PostgreSql
                         transaction.Commit();
                     }
                 }
-                catch (PostgresException ex) when (ex.SqlState is "23505" or "42P07")
+                catch (PostgresException ex) when (ex.SqlState is PostgresErrorCodes.DuplicateTable or  // 42P07
+                    PostgresErrorCodes.DuplicateObject or  // 42710
+                    PostgresErrorCodes.UniqueViolation)    // 23505
                 {
-                    //PostgreSQL error code 23505: unique_violation or 42P07: relation already exists, is returned
-                    //if the table creation is executed concurrently by multiple transactions
+                    //This happens if the table creation is executed concurrently by multiple transactions
                     //In this case we want to discard the exception and continue
                     Logger.Debug("Subscription Table already exists.", ex);
                 }


### PR DESCRIPTION
This change handles errors thrown when tables are being created concurrently. It seems that already existing issues surfaced after updating to Core version 10, likely due to some concurrency-related changes:
- https://github.com/Particular/NServiceBus.SqlServer/actions/runs/21221475978