### PR TITLE
Test Updates for .NET 11 Preview 4 - master

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "11.0.0",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.0",
+    "version": "11.0.100-preview.4.26230.115",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/NServiceBus.Transport.PostgreSql.AcceptanceTests/NServiceBus.Transport.PostgreSql.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.PostgreSql.AcceptanceTests/NServiceBus.Transport.PostgreSql.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.PostgreSql.TransportTests/NServiceBus.Transport.PostgreSql.TransportTests.csproj
+++ b/src/NServiceBus.Transport.PostgreSql.TransportTests/NServiceBus.Transport.PostgreSql.TransportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.PostgreSql.UnitTests/NServiceBus.Transport.PostgreSql.UnitTests.csproj
+++ b/src/NServiceBus.Transport.PostgreSql.UnitTests/NServiceBus.Transport.PostgreSql.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.PostgreSql/NServiceBus.Transport.PostgreSql.csproj
+++ b/src/NServiceBus.Transport.PostgreSql/NServiceBus.Transport.PostgreSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NServiceBus.Transport.SqlServer.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NServiceBus.Transport.SqlServer.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.SqlServer.IntegrationTests/NServiceBus.Transport.SqlServer.IntegrationTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.IntegrationTests/NServiceBus.Transport.SqlServer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.SqlServer.TransportTests/NServiceBus.Transport.SqlServer.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.TransportTests/NServiceBus.Transport.SqlServer.TransportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/NServiceBus.Transport.SqlServer.UnitTests.csproj
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/NServiceBus.Transport.SqlServer.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />

--- a/src/NServiceBus.Transport.SqlServer/NServiceBus.Transport.SqlServer.csproj
+++ b/src/NServiceBus.Transport.SqlServer/NServiceBus.Transport.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
* Set test project target frameworks (not including .NET Framework) to `net11.0`
* Updated .NET SDK in global.json to `11.0.0`