### PR TITLE
Refactor SHA256 hash computation for better resource management

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
@@ -91,7 +91,8 @@ namespace NServiceBus.Transport.PostgreSql
         static long CalculateLockId(string text)
         {
             var byteContents = Encoding.Unicode.GetBytes(text);
-            var hashText = SHA256.Create().ComputeHash(byteContents);
+            using var sha256 = SHA256.Create();
+            var hashText = sha256.ComputeHash(byteContents);
 
             //HINT: we assume that the first byte has the same collision probability as any other part of the hash
             return BitConverter.ToInt64(hashText, 0);

--- a/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
@@ -91,8 +91,7 @@ namespace NServiceBus.Transport.PostgreSql
         static long CalculateLockId(string text)
         {
             var byteContents = Encoding.Unicode.GetBytes(text);
-            using var sha256 = SHA256.Create();
-            var hashText = sha256.ComputeHash(byteContents);
+            var hashText = SHA256.HashData(byteContents);
 
             //HINT: we assume that the first byte has the same collision probability as any other part of the hash
             return BitConverter.ToInt64(hashText, 0);

--- a/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Receiving/QueueCreator.cs
@@ -11,18 +11,8 @@ namespace NServiceBus.Transport.PostgreSql
     using Npgsql;
     using NServiceBus.Transport.Sql.Shared;
 
-    class QueueCreator
+    class QueueCreator(ISqlConstants sqlConstants, DbConnectionFactory connectionFactory, Func<string, CanonicalQueueAddress> addressTranslator, bool createMessageBodyColumn = false)
     {
-        static ILog Logger = LogManager.GetLogger<QueueCreator>();
-
-        public QueueCreator(ISqlConstants sqlConstants, DbConnectionFactory connectionFactory, Func<string, CanonicalQueueAddress> addressTranslator, bool createMessageBodyColumn = false)
-        {
-            this.sqlConstants = sqlConstants;
-            this.connectionFactory = connectionFactory;
-            this.addressTranslator = addressTranslator;
-            this.createMessageBodyColumn = createMessageBodyColumn;
-        }
-
         public async Task CreateQueueIfNecessary(string[] queueAddresses, CanonicalQueueAddress delayedQueueAddress, CancellationToken cancellationToken = default)
         {
             using var connection = await connectionFactory.OpenNewConnection(cancellationToken).ConfigureAwait(false);
@@ -97,9 +87,6 @@ namespace NServiceBus.Transport.PostgreSql
             return BitConverter.ToInt64(hashText, 0);
         }
 
-        ISqlConstants sqlConstants;
-        DbConnectionFactory connectionFactory;
-        Func<string, CanonicalQueueAddress> addressTranslator;
-        bool createMessageBodyColumn;
+        static readonly ILog Logger = LogManager.GetLogger<QueueCreator>();
     }
 }


### PR DESCRIPTION
This pull request refactors the `QueueCreator` class in the `NServiceBus.Transport.PostgreSql` namespace to use C# primary constructor syntax and makes a minor update to the hash calculation method. The changes also shift the logger to a static readonly field and clean up field declarations.

Class refactoring and initialization:

* Refactored `QueueCreator` to use a primary constructor, removing explicit field declarations and the constructor body. This simplifies the code and leverages modern C# syntax.

Logging:

* Changed the logger declaration to a static readonly field, moving it to the bottom of the class for clarity and to match conventions.

Hash calculation update:

* Updated the SHA-256 hash calculation in `CalculateLockId` to use `SHA256.HashData` instead of creating a new SHA256 instance, improving efficiency and clarity.