### PR TITLE
Refactor DictionarySerializer for improved memory stream handling

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Queuing/DictionarySerializer.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Queuing/DictionarySerializer.cs
@@ -11,7 +11,7 @@
         {
             using var stream = new MemoryStream();
             serializer.WriteObject(stream, instance);
-            return stream.TryGetBuffer(out var buffer) ? Encoding.UTF8.GetString(buffer) : Encoding.UTF8.GetString(stream.GetBuffer());
+            return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
         }
 
         public static Dictionary<string, string> DeSerialize(string json)

--- a/src/NServiceBus.Transport.Sql.Shared/Queuing/DictionarySerializer.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Queuing/DictionarySerializer.cs
@@ -9,22 +9,18 @@
     {
         public static string Serialize(Dictionary<string, string> instance)
         {
-            using (var stream = new MemoryStream())
-            {
-                serializer.WriteObject(stream, instance);
-                return Encoding.UTF8.GetString(stream.ToArray());
-            }
+            using var stream = new MemoryStream();
+            serializer.WriteObject(stream, instance);
+            return stream.TryGetBuffer(out var buffer) ? Encoding.UTF8.GetString(buffer) : Encoding.UTF8.GetString(stream.GetBuffer());
         }
 
         public static Dictionary<string, string> DeSerialize(string json)
         {
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-            {
-                return (Dictionary<string, string>)serializer.ReadObject(stream);
-            }
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return (Dictionary<string, string>)serializer.ReadObject(stream);
         }
 
-        static DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(Dictionary<string, string>), new DataContractJsonSerializerSettings
+        static readonly DataContractJsonSerializer serializer = new(typeof(Dictionary<string, string>), new DataContractJsonSerializerSettings
         {
             UseSimpleDictionaryFormat = true
         });


### PR DESCRIPTION
This pull request refactors the `DictionarySerializer` class to modernize its code style and improve performance in serialization and deserialization. The main changes include adopting C# 8.0+ syntax for `using` statements, optimizing buffer usage, and ensuring immutability for the serializer instance.

**Code style and performance improvements:**

* Replaced the traditional `using` statement block with the newer C# syntax (`using var`) for `MemoryStream` in both `Serialize` and `DeSerialize` methods, making the code more concise and readable.
* Optimized the serialization process by using `TryGetBuffer` to avoid unnecessary allocations when converting the stream to a UTF-8 string.
* Made the `serializer` field `readonly` and used target-typed `new` for cleaner and safer initialization.