### PR TITLE
Fix PostgreSQL constants for table and column existence checks

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/PostgreSqlConstants.cs
+++ b/src/NServiceBus.Transport.PostgreSql/PostgreSqlConstants.cs
@@ -60,7 +60,7 @@ SELECT COALESCE(cast((SELECT seq FROM {0} ORDER BY seq DESC LIMIT 1 FOR UPDATE S
 DO $$
 BEGIN
 
-IF EXISTS (
+IF NOT EXISTS (
    SELECT FROM information_schema.tables 
    WHERE  table_schema = '{0}'
    AND    table_name   = '{1}'
@@ -69,11 +69,11 @@ THEN
     RETURN;
 END IF;
 
-IF NOT EXISTS (
+IF EXISTS (
     SELECT FROM information_schema.columns 
     WHERE  table_schema = '{0}'
     AND table_name='{1}' 
-    AND column_name='StringBody'
+    AND column_name='bodystring'
     )
 THEN
     RETURN;
@@ -85,7 +85,7 @@ IF EXISTS (
     SELECT FROM information_schema.columns 
     WHERE  table_schema = '{0}'
     AND table_name='{1}' 
-    AND column_name='StringBody'
+    AND column_name='bodystring'
     )
 THEN
     


### PR DESCRIPTION
This pull request corrects the logic in the SQL migration script within `PostgreSqlConstants.cs` to ensure proper detection of table and column existence. The changes address issues where the existence checks for tables and columns were inverted or used incorrect column names.

Schema migration logic corrections:

* Fixed table existence check to use `NOT EXISTS` instead of `EXISTS`, ensuring the migration only runs when the table does not exist.
* Fixed column existence check to use `EXISTS` instead of `NOT EXISTS`, ensuring the migration only runs if the column already exists.
* Updated column name in existence checks from `'StringBody'` to `'bodystring'` to match the actual schema. [[1]](diffhunk://#diff-2ea4da887e971dd600961d0b964f60358ca06e80c91846183af829fa7bf76ab6L72-R76) [[2]](diffhunk://#diff-2ea4da887e971dd600961d0b964f60358ca06e80c91846183af829fa7bf76ab6L88-R88)