### PR TITLE
Stabilize SQL Server plan cache for message inserts by sizing `Headers` as `nvarchar(max)`

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/StoreDelayedMessageCommand.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/StoreDelayedMessageCommand.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Transport.Sql.Shared
 
         public void PrepareSendCommand(DbCommand command)
         {
-            command.AddParameter("Headers", DbType.String, headers);
+            command.AddParameter("Headers", DbType.String, headers, -1);
             command.AddParameter("Body", DbType.Binary, bodyBytes);
             command.AddParameter("DueAfterDays", DbType.Int32, dueAfter.Days);
             command.AddParameter("DueAfterHours", DbType.Int32, dueAfter.Hours);

--- a/src/NServiceBus.Transport.Sql.Shared/Queuing/MessageRow.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Queuing/MessageRow.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.Transport.Sql.Shared
         {
             command.AddParameter("Id", DbType.Guid, id);
             command.AddParameter("TimeToBeReceivedMs", DbType.Int32, timeToBeReceived);
-            command.AddParameter("Headers", DbType.String, headers);
+            command.AddParameter("Headers", DbType.String, headers, -1);
             command.AddParameter("Body", DbType.Binary, bodyBytes, -1);
         }
 


### PR DESCRIPTION
**Summary**  
This change sets `Size = -1` for the `Headers` parameter in SQL shared send commands so SQL Server binds it as `nvarchar(max)` instead of inferring `nvarchar(<len>)` from each message.

**Changes**  
- `NServiceBus.Transport.Sql.Shared/Queuing/MessageRow.cs`  
  - `AddParameter("Headers", DbType.String, headers)` -> `AddParameter("Headers", DbType.String, headers, -1)`
- `NServiceBus.Transport.Sql.Shared/DelayedDelivery/StoreDelayedMessageCommand.cs`  
  - `AddParameter("Headers", DbType.String, headers)` -> `AddParameter("Headers", DbType.String, headers, -1)`

**Why**  
Without explicit size, Microsoft.Data.SqlClient infers parameter length per value, which can produce multiple cached plans for otherwise identical insert commands. Since the destination column is `nvarchar(max)`, `-1` is the correct and plan-stable parameter size.

**Impact**  
- SQL Server: reduces avoidable plan cache fragmentation/churn on per-message inserts.  
- PostgreSQL/Npgsql: no behavioral change (text size is ignored there).

**Risk**  
Low. Parameter metadata-only change; no schema or functional behavior change.

**Validation**  
- Verified both SQL shared send paths now set `Headers` with `-1`.