### PR TITLE
Postgres cache send command

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql/PostgreSqlTableBasedQueue.cs
+++ b/src/NServiceBus.Transport.PostgreSql/PostgreSqlTableBasedQueue.cs
@@ -21,16 +21,14 @@ class PostgreSqlTableBasedQueue(PostgreSqlConstants sqlConstants, string qualifi
     {
         try
         {
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandType = CommandType.Text;
-                command.CommandText = sendCommand;
-                command.Transaction = transaction;
+            using var command = connection.CreateCommand();
+            command.CommandType = CommandType.Text;
+            command.CommandText = sendCommand;
+            command.Transaction = transaction;
 
-                message.PrepareSendCommand(command);
+            message.PrepareSendCommand(command);
 
-                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            }
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
         // see: PostgreSQL: Documentation: 16: Appendix A. PostgreSQL Error Codes
         catch (NpgsqlException ex) when (ex.SqlState == "42P01")

--- a/src/NServiceBus.Transport.PostgreSql/PostgreSqlTableBasedQueue.cs
+++ b/src/NServiceBus.Transport.PostgreSql/PostgreSqlTableBasedQueue.cs
@@ -11,23 +11,16 @@ using Unicast.Queuing;
 
 using static System.String;
 
-class PostgreSqlTableBasedQueue : TableBasedQueue
+class PostgreSqlTableBasedQueue(PostgreSqlConstants sqlConstants, string qualifiedTableName, string queueName, bool isStreamSupported)
+    : TableBasedQueue(sqlConstants, qualifiedTableName, queueName, isStreamSupported)
 {
-    readonly PostgreSqlConstants postgreSqlConstants;
-
-    public PostgreSqlTableBasedQueue(PostgreSqlConstants sqlConstants, string qualifiedTableName, string queueName, bool isStreamSupported) :
-        base(sqlConstants, qualifiedTableName, queueName, isStreamSupported)
-    {
-        postgreSqlConstants = sqlConstants;
-    }
+    readonly string sendCommand = Format(sqlConstants.SendText, qualifiedTableName);
 
     protected override async Task SendRawMessage(MessageRow message, DbConnection connection, DbTransaction transaction,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            var sendCommand = Format(postgreSqlConstants.SendText, qualifiedTableName);
-
             using (var command = connection.CreateCommand())
             {
                 command.CommandType = CommandType.Text;


### PR DESCRIPTION
This pull request refactors the `PostgreSqlTableBasedQueue` class to streamline its construction and improve code clarity. The main changes involve converting the class to use a primary constructor, removing redundant fields, and simplifying resource management in the `SendRawMessage` method.

### Refactoring and Code Simplification

* Converted `PostgreSqlTableBasedQueue` to use a primary constructor, eliminating the explicit constructor and redundant `postgreSqlConstants` field.
* Moved initialization of the `sendCommand` string to a readonly field, reducing repeated string formatting in the method.
* Simplified the `SendRawMessage` method by using a `using var` statement for the command object, modernizing resource management.
* Removed an unnecessary closing brace in the `SendRawMessage` method, improving code readability.