### PR TITLE
Fix receive latch double-signal by making ReceiveCountdownEvent.Signaler a reference type

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
@@ -37,7 +37,7 @@ class ReceiveCountdownEvent
         }
     }
 
-    public struct Signaler(ReceiveCountdownEvent parent) : IDisposable
+    public sealed class Signaler(ReceiveCountdownEvent parent) : IDisposable
     {
         bool signalled;
 


### PR DESCRIPTION
Follow up on:

- #1627

This PR fixes a regression in receive throttling where the receive latch could be signaled twice per receive task.

**Problem**  
`ReceiveCountdownEvent.Signaler` was a mutable `struct` passed by value into `ProcessStrategy.ProcessMessage(...)`.  
That meant:

1. `Signal()` in the processing strategy mutated/signaled a copy.
2. The caller’s `using` variable still had `signalled == false`.
3. `Dispose()` then signaled again.

Result: latch countdown could reach zero early, allowing the receiver loop to re-peek before all receive operations completed.

Passing by `ref` is not viable across this async flow. A reference type is the simplest safe fix and keeps existing call patterns intact.
