### PR TITLE
Concurrent delayed delivery backoff scheduling race

### DIFF
--- a/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/DelayedDelivery/BackOffStrategy.cs
@@ -5,101 +5,147 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 
-class BackOffStrategy
+class BackOffStrategy(TimeProvider timeProvider)
 {
     public BackOffStrategy() : this(TimeProvider.System) { }
 
-    public BackOffStrategy(TimeProvider timeProvider)
-    {
-        this.timeProvider = timeProvider;
-
-        NextExecutionTime = timeProvider.GetUtcNow().UtcDateTime.AddSeconds(2);
-        NextDelayedMessage = timeProvider.GetUtcNow().UtcDateTime;
-    }
-
-    public void RegisterNewDueTime(DateTime dueTime)
-    {
-        NextDelayedMessage = dueTime;
-
-        if (dueTime == DateTime.MinValue)
+    public void RegisterNewDueTime(DateTime dueTime) =>
+        UpdateState(static (current, dueTime) =>
         {
-            Logger.Debug("No delayed messages available...");
-            DelayedMessageAvailable = false;
-            return;
-        }
+            if (dueTime == DateTime.MinValue)
+            {
+                Logger.Debug("No delayed messages available...");
+                return current with
+                {
+                    NextDelayedMessage = dueTime,
+                    DelayedMessageAvailable = false
+                };
+            }
 
-        if (dueTime < NextExecutionTime)
-        {
-            Logger.Debug("New delayed message registered with dueTime earlier than previously known next dueTime");
-            DelayedMessageAvailable = true;
-            NextExecutionTime = dueTime;
-            return;
-        }
+            if (dueTime < current.NextExecutionTime)
+            {
+                Logger.Debug("New delayed message registered with dueTime earlier than previously known next dueTime");
+                return current with
+                {
+                    NextDelayedMessage = dueTime,
+                    NextExecutionTime = dueTime,
+                    DelayedMessageAvailable = true
+                };
+            }
 
-        Logger.Debug("Delayed messages found but dueTime is later than time to peek for new delayed messages.");
-        DelayedMessageAvailable = true;
-    }
+            Logger.Debug("Delayed messages found but dueTime is later than time to peek for new delayed messages.");
+            return current with
+            {
+                NextDelayedMessage = dueTime,
+                DelayedMessageAvailable = true
+            };
+        }, dueTime);
 
     public async Task WaitForNextExecution(CancellationToken cancellationToken = default)
     {
         var now = timeProvider.GetUtcNow();
-        CalculateNextExecutionTime(now);
+        UpdateState(static (current, now) => CalculateNextExecutionTime(current, now), now);
 
         // While running this loop, a new delayed message can be stored
         // and NextExecutionTime could be set to a new (sooner) time.
-        TimeSpan waitTime;
-        while ((waitTime = NextExecutionTime - now) > TimeSpan.Zero)
+        while (true)
         {
+            var current = Volatile.Read(ref state);
+            var waitTime = current.NextExecutionTime - now;
+            if (waitTime <= TimeSpan.Zero)
+            {
+                var nextState = current with
+                {
+                    NextExecutionTime = DateTime.MaxValue
+                };
+
+                if (Interlocked.CompareExchange(ref state, nextState, current) == current)
+                {
+                    return;
+                }
+
+                continue;
+            }
+
             waitTime = waitTime < oneSecond ? waitTime : oneSecond;
             await Task.Delay(waitTime, timeProvider, cancellationToken).ConfigureAwait(false);
 
             now = timeProvider.GetUtcNow();
         }
-
-        NextExecutionTime = DateTime.MaxValue;
     }
 
-    void CalculateNextExecutionTime(DateTimeOffset now)
+    static BackOffState CalculateNextExecutionTime(BackOffState current, DateTimeOffset now)
     {
-        IncreaseExponentialBackOff();
+        var milliseconds = IncreaseExponentialBackOff(current.Milliseconds);
 
         var calculatedBackoffTime = now.AddMilliseconds(milliseconds);
 
         // If the next delayed message is coming up before the back-off time, use that.
-        if (DelayedMessageAvailable && calculatedBackoffTime > NextDelayedMessage)
+        if (current.DelayedMessageAvailable && calculatedBackoffTime > current.NextDelayedMessage)
         {
             Logger.Debug(
-                $"Scheduling next attempt to move matured delayed messages for time of next message due at {NextDelayedMessage}.");
-            NextExecutionTime = NextDelayedMessage;
+                $"Scheduling next attempt to move matured delayed messages for time of next message due at {current.NextDelayedMessage}.");
             // We find a better time to execute, so we can reset the exponential back off
-            milliseconds = InitialBackOffTime;
-            return;
+            return current with
+            {
+                NextExecutionTime = current.NextDelayedMessage,
+                Milliseconds = InitialBackOffTime
+            };
         }
 
         Logger.Debug(
             $"Exponentially backing off for {milliseconds / 1000} seconds until {calculatedBackoffTime.UtcDateTime}.");
-        NextExecutionTime = calculatedBackoffTime.UtcDateTime;
+        return current with
+        {
+            NextExecutionTime = calculatedBackoffTime.UtcDateTime,
+            Milliseconds = milliseconds
+        };
     }
 
-    void IncreaseExponentialBackOff()
+    static int IncreaseExponentialBackOff(int milliseconds)
     {
         milliseconds *= 2;
         if (milliseconds > MaximumDelayUntilNextPeek)
         {
             milliseconds = MaximumDelayUntilNextPeek;
         }
+
+        return milliseconds;
+    }
+
+    void UpdateState<TArg>(Func<BackOffState, TArg, BackOffState> update, TArg arg)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref state);
+            var next = update(current, arg);
+            if (Interlocked.CompareExchange(ref state, next, current) == current)
+            {
+                return;
+            }
+        }
     }
 
     const int MaximumDelayUntilNextPeek = 60000;
     const int InitialBackOffTime = 500;
 
-    internal DateTime NextDelayedMessage { get; private set; }
-    internal DateTime NextExecutionTime { get; private set; }
-    bool DelayedMessageAvailable { get; set; }
+    internal DateTime NextDelayedMessage => Volatile.Read(ref state).NextDelayedMessage;
 
-    int milliseconds = InitialBackOffTime; // First time multiplied will be 1 second.
+    internal DateTime NextExecutionTime => Volatile.Read(ref state).NextExecutionTime;
+
     static readonly ILog Logger = LogManager.GetLogger<BackOffStrategy>();
 
-    readonly TimeProvider timeProvider;
+    BackOffState state = new(
+        timeProvider.GetUtcNow().UtcDateTime,
+        timeProvider.GetUtcNow().UtcDateTime.AddSeconds(2),
+        false,
+        InitialBackOffTime);
+
     readonly TimeSpan oneSecond = TimeSpan.FromSeconds(1);
+
+    sealed record BackOffState(
+        DateTime NextDelayedMessage,
+        DateTime NextExecutionTime,
+        bool DelayedMessageAvailable,
+        int Milliseconds);
 }

--- a/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
+++ b/src/NServiceBus.Transport.Sql.Shared/Receiving/ReceiveCountdownEvent.cs
@@ -37,7 +37,7 @@ class ReceiveCountdownEvent
         }
     }
 
-    public struct Signaler(ReceiveCountdownEvent parent) : IDisposable
+    public sealed class Signaler(ReceiveCountdownEvent parent) : IDisposable
     {
         bool signalled;
 

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/DelayedDelivery/BackOffStrategyTests.cs
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/DelayedDelivery/BackOffStrategyTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.SqlServer.UnitTests.DelayedDelivery;
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Time.Testing;
@@ -19,12 +20,12 @@ public class BackOffStrategyTests
 
         await strategy.WaitForNextExecution().ConfigureAwait(false);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // We ignore calculating the time to wait, because that's not interesting in this test.
             Assert.That(strategy.NextDelayedMessage, Is.EqualTo(expectedNextDelayedMessage));
             Assert.That(strategy.NextExecutionTime, Is.EqualTo(DateTime.MaxValue));
-        });
+        }
     }
 
     [Test]
@@ -37,12 +38,12 @@ public class BackOffStrategyTests
 
         await strategy.WaitForNextExecution().ConfigureAwait(false);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // We ignore calculating the time to wait, because that's not interesting in this test.
             Assert.That(strategy.NextDelayedMessage, Is.EqualTo(expectedNextDelayedMessage));
             Assert.That(strategy.NextExecutionTime, Is.EqualTo(DateTime.MaxValue));
-        });
+        }
     }
 
     [Test]
@@ -116,11 +117,11 @@ public class BackOffStrategyTests
         var x = RoundOff(now, now.AddMilliseconds(999));
         var y = RoundOff(now, now.AddMilliseconds(1001));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(x, Is.EqualTo(0));
             Assert.That(y, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -143,6 +144,52 @@ public class BackOffStrategyTests
         Assert.That(timeProvider.DueTime, Is.EqualTo(oneMillisecond));
     }
 
+    [Test]
+    public void When_Multiple_DueTimes_Are_Registered_Concurrently_Should_Use_Earliest_Execution_Time()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var earliestDueTime = now.AddMilliseconds(1);
+        var dueTimes = Enumerable.Range(1, 1000)
+            .Select(offset => now.AddMilliseconds(offset))
+            .Reverse()
+            .ToArray();
+
+        Parallel.ForEach(dueTimes, strategy.RegisterNewDueTime);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(strategy.NextExecutionTime, Is.EqualTo(earliestDueTime));
+            Assert.That(strategy.NextDelayedMessage, Is.Not.EqualTo(DateTime.MinValue));
+        }
+    }
+
+    [Test]
+    public async Task When_DueTime_Is_Registered_While_Waiting_Should_Complete_After_Next_WakeUp()
+    {
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
+        strategy.RegisterNewDueTime(DateTime.MinValue);
+
+        var waitTask = strategy.WaitForNextExecution();
+
+        await timeProvider.TimerCreated.ConfigureAwait(false);
+        var dueTime = timeProvider.GetUtcNow().UtcDateTime.AddMilliseconds(100);
+        strategy.RegisterNewDueTime(dueTime);
+
+        Assert.That(waitTask.IsCompleted, Is.False);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await waitTask.ConfigureAwait(false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(strategy.NextDelayedMessage, Is.EqualTo(dueTime));
+            Assert.That(strategy.NextExecutionTime, Is.EqualTo(DateTime.MaxValue));
+        }
+    }
+
     /// <summary>
     /// Prevent flaky tests by allowing 999ms offset
     /// </summary>
@@ -155,11 +202,15 @@ public class BackOffStrategyTests
     class CaptureWhenTimerDueTimeProvider : FakeTimeProvider
     {
         public TimeSpan DueTime { get; private set; }
+        public Task TimerCreated => timerCreated.Task;
 
         public override ITimer CreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
         {
             DueTime = dueTime;
+            _ = timerCreated.TrySetResult();
             return base.CreateTimer(callback, state, dueTime, period);
         }
+
+        readonly TaskCompletionSource timerCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/DelayedDelivery/BackOffStrategyTests.cs
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/DelayedDelivery/BackOffStrategyTests.cs
@@ -13,12 +13,13 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_NewDueTime_Is_Earlier_Then_LastKnownDueTime_Should_Use_NewDueTime()
     {
-        var strategy = new BackOffStrategy();
-        DateTime expectedNextDelayedMessage = DateTime.UtcNow.AddSeconds(1);
-        strategy.RegisterNewDueTime(DateTime.UtcNow.AddSeconds(5));
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
+        DateTime expectedNextDelayedMessage = timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1);
+        strategy.RegisterNewDueTime(timeProvider.GetUtcNow().UtcDateTime.AddSeconds(5));
         strategy.RegisterNewDueTime(expectedNextDelayedMessage);
 
-        await strategy.WaitForNextExecution().ConfigureAwait(false);
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -31,12 +32,13 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_NewDueTime_Is_Later_Then_LastKnownDueTime_Should_Ignore_It_For_Now()
     {
-        var strategy = new BackOffStrategy();
-        DateTime expectedNextDelayedMessage = DateTime.UtcNow.AddSeconds(10);
-        strategy.RegisterNewDueTime(DateTime.UtcNow.AddSeconds(5));
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
+        DateTime expectedNextDelayedMessage = timeProvider.GetUtcNow().UtcDateTime.AddSeconds(10);
+        strategy.RegisterNewDueTime(timeProvider.GetUtcNow().UtcDateTime.AddSeconds(5));
         strategy.RegisterNewDueTime(expectedNextDelayedMessage);
 
-        await strategy.WaitForNextExecution().ConfigureAwait(false);
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -49,14 +51,15 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_No_DelayedMessages_Available_Should_Backoff_Exponentially()
     {
-        var strategy = new BackOffStrategy();
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(DateTime.MinValue);
 
-        var beforeWaiting = DateTime.UtcNow;
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 1 second
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 2 more seconds
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 4 more seconds
-        var afterWaiting = DateTime.UtcNow;
+        var beforeWaiting = timeProvider.GetUtcNow().UtcDateTime;
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 1 second
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 2 more seconds
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 4 more seconds
+        var afterWaiting = timeProvider.GetUtcNow().UtcDateTime;
 
         Assert.That(RoundOff(beforeWaiting, afterWaiting), Is.EqualTo(7));
     }
@@ -64,15 +67,16 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_NextDelayedMessage_Is_Sooner_Than_ExponentialBackoff_Should_Use_NextDelayeMessageDueTime()
     {
-        var strategy = new BackOffStrategy();
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(DateTime.MinValue);
 
-        var beforeWaiting = DateTime.UtcNow;
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 1 second
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 2 more seconds
-        strategy.RegisterNewDueTime(DateTime.UtcNow.AddSeconds(1)); // waits 1 more second
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // does NOT wait 4 more seconds
-        var afterWaiting = DateTime.UtcNow;
+        var beforeWaiting = timeProvider.GetUtcNow().UtcDateTime;
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 1 second
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 2 more seconds
+        strategy.RegisterNewDueTime(timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1)); // waits 1 more second
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // does NOT wait 4 more seconds
+        var afterWaiting = timeProvider.GetUtcNow().UtcDateTime;
 
         Assert.That(RoundOff(beforeWaiting, afterWaiting), Is.EqualTo(4));
     }
@@ -80,15 +84,16 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_NextDelayedMessage_Is_Later_Than_ExponentialBackoff_Should_Use_ExponentialBackoffTime()
     {
-        var strategy = new BackOffStrategy();
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(DateTime.MinValue);
 
-        var beforeWaiting = DateTime.UtcNow;
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 1 second
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 2 more seconds
-        strategy.RegisterNewDueTime(DateTime.UtcNow.AddSeconds(10));
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 4 more seconds
-        var afterWaiting = DateTime.UtcNow;
+        var beforeWaiting = timeProvider.GetUtcNow().UtcDateTime;
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 1 second
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 2 more seconds
+        strategy.RegisterNewDueTime(timeProvider.GetUtcNow().UtcDateTime.AddSeconds(10));
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 4 more seconds
+        var afterWaiting = timeProvider.GetUtcNow().UtcDateTime;
 
         Assert.That(RoundOff(beforeWaiting, afterWaiting), Is.EqualTo(7));
     }
@@ -96,16 +101,17 @@ public class BackOffStrategyTests
     [Test]
     public async Task When_NextDelayedMessage_Is_Up_Than_ExponentialBackoff_Should_Use_NextDelayeMessageDueTime()
     {
-        var strategy = new BackOffStrategy();
+        var timeProvider = new CaptureWhenTimerDueTimeProvider();
+        var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(DateTime.MinValue);
 
-        var beforeWaiting = DateTime.UtcNow;
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 1 second
-        strategy.RegisterNewDueTime(DateTime.UtcNow.AddSeconds(4));
-        await strategy.WaitForNextExecution().ConfigureAwait(false); // waits 2 more seconds
+        var beforeWaiting = timeProvider.GetUtcNow().UtcDateTime;
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 1 second
+        strategy.RegisterNewDueTime(timeProvider.GetUtcNow().UtcDateTime.AddSeconds(4));
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false); // waits 2 more seconds
         // Following line waits 2 more seconds because of next delayed message is up.
-        await strategy.WaitForNextExecution().ConfigureAwait(false);
-        var afterWaiting = DateTime.UtcNow;
+        await WaitForNextExecution(strategy, timeProvider, CancellationToken.None).ConfigureAwait(false);
+        var afterWaiting = timeProvider.GetUtcNow().UtcDateTime;
 
         Assert.That(RoundOff(beforeWaiting, afterWaiting), Is.EqualTo(5));
     }
@@ -113,35 +119,33 @@ public class BackOffStrategyTests
     [Test]
     public void When_AfterWaiting_Takes_Little_Over_A_Second_Should_Still_Count_As_Second()
     {
-        var now = DateTime.UtcNow;
+        var now = new DateTime(2026, 6, 9, 10, 0, 0, DateTimeKind.Utc);
         var x = RoundOff(now, now.AddMilliseconds(999));
         var y = RoundOff(now, now.AddMilliseconds(1001));
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(x, Is.EqualTo(0));
+            Assert.That(x, Is.Zero);
             Assert.That(y, Is.EqualTo(1));
         }
     }
 
     [Test]
-    public void When_WaitForNextExecution_Waits_It_Should_Wait_For_Exact_Difference_Between_Now_And_Next_Due_Time()
+    public async Task When_WaitForNextExecution_Waits_It_Should_Wait_For_Exact_Difference_Between_Now_And_Next_Due_Time()
     {
         // Arrange
         var oneMillisecond = TimeSpan.FromMilliseconds(1);
         var timeProvider = new CaptureWhenTimerDueTimeProvider();
         var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(timeProvider.GetUtcNow().Add(oneMillisecond).UtcDateTime);
-        timeProvider.AutoAdvanceAmount = oneMillisecond;
+        var timerVersion = timeProvider.TimerVersion;
 
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1), TimeProvider.System);
+        var waitTask = strategy.WaitForNextExecution();
+        var timer = await timeProvider.WaitForTimerCreatedAfter(timerVersion, CancellationToken.None).ConfigureAwait(false);
+        timeProvider.Advance(timer.DueTime);
+        await waitTask.ConfigureAwait(false);
 
-        // Act
-        async Task action() => await strategy.WaitForNextExecution(cts.Token).ConfigureAwait(false);
-
-        // Assert
-        Assert.ThrowsAsync<TaskCanceledException>(action);
-        Assert.That(timeProvider.DueTime, Is.EqualTo(oneMillisecond));
+        Assert.That(timer.DueTime, Is.EqualTo(oneMillisecond));
     }
 
     [Test]
@@ -172,15 +176,15 @@ public class BackOffStrategyTests
         var strategy = new BackOffStrategy(timeProvider);
         strategy.RegisterNewDueTime(DateTime.MinValue);
 
+        var timerVersion = timeProvider.TimerVersion;
         var waitTask = strategy.WaitForNextExecution();
-
-        await timeProvider.TimerCreated.ConfigureAwait(false);
+        var timer = await timeProvider.WaitForTimerCreatedAfter(timerVersion, CancellationToken.None).ConfigureAwait(false);
         var dueTime = timeProvider.GetUtcNow().UtcDateTime.AddMilliseconds(100);
         strategy.RegisterNewDueTime(dueTime);
 
         Assert.That(waitTask.IsCompleted, Is.False);
 
-        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        timeProvider.Advance(timer.DueTime);
         await waitTask.ConfigureAwait(false);
 
         using (Assert.EnterMultipleScope())
@@ -188,6 +192,29 @@ public class BackOffStrategyTests
             Assert.That(strategy.NextDelayedMessage, Is.EqualTo(dueTime));
             Assert.That(strategy.NextExecutionTime, Is.EqualTo(DateTime.MaxValue));
         }
+    }
+
+    static async Task WaitForNextExecution(BackOffStrategy strategy, CaptureWhenTimerDueTimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        var timerVersion = timeProvider.TimerVersion;
+        var waitTask = strategy.WaitForNextExecution(cancellationToken);
+
+        while (!waitTask.IsCompleted)
+        {
+            var timerCreated = timeProvider.WaitForTimerCreatedAfter(timerVersion, cancellationToken);
+            var completedTask = await Task.WhenAny(waitTask, timerCreated).ConfigureAwait(false);
+            if (completedTask == waitTask)
+            {
+                break;
+            }
+
+            var timer = await timerCreated.ConfigureAwait(false);
+            timerVersion = timer.Version;
+            timeProvider.Advance(timer.DueTime);
+        }
+
+        await waitTask.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -201,16 +228,56 @@ public class BackOffStrategyTests
 
     class CaptureWhenTimerDueTimeProvider : FakeTimeProvider
     {
-        public TimeSpan DueTime { get; private set; }
-        public Task TimerCreated => timerCreated.Task;
+        public int TimerVersion
+        {
+            get
+            {
+                lock (syncRoot)
+                {
+                    return timerVersion;
+                }
+            }
+        }
+
+        public Task<TimerInfo> WaitForTimerCreatedAfter(int observedTimerVersion, CancellationToken cancellationToken = default)
+        {
+            lock (syncRoot)
+            {
+                if (timerVersion > observedTimerVersion)
+                {
+                    return Task.FromResult(new TimerInfo(timerVersion, dueTime));
+                }
+
+                return timerCreated.Task.WaitAsync(cancellationToken);
+            }
+        }
 
         public override ITimer CreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            DueTime = dueTime;
-            _ = timerCreated.TrySetResult();
+            TaskCompletionSource<TimerInfo> created;
+            TimerInfo timerInfo;
+
+            lock (syncRoot)
+            {
+                this.dueTime = dueTime;
+                timerVersion++;
+                timerInfo = new TimerInfo(timerVersion, dueTime);
+                created = timerCreated;
+                timerCreated = CreateTimerCreatedTask();
+            }
+
+            _ = created.TrySetResult(timerInfo);
             return base.CreateTimer(callback, state, dueTime, period);
         }
 
-        readonly TaskCompletionSource timerCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        static TaskCompletionSource<TimerInfo> CreateTimerCreatedTask() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        readonly Lock syncRoot = new();
+        TaskCompletionSource<TimerInfo> timerCreated = CreateTimerCreatedTask();
+        TimeSpan dueTime;
+        int timerVersion;
+
+        public sealed record TimerInfo(int Version, TimeSpan DueTime);
     }
 }


### PR DESCRIPTION
Fixes a race in `BackOffStrategy` where delayed-message due-time notifications could concurrently mutate shared scheduling state while the delayed delivery processor was calculating or waiting for the next execution time.

The state is now updated atomically, so `NextExecutionTime`, `NextDelayedMessage`, delayed-message availability, and the exponential backoff interval remain consistent when `RegisterNewDueTime` is called concurrently with WaitForNextExecution.

Added coverage for:

- concurrent due-time registrations preserving the earliest execution time
- due-time registration while the processor is already waiting
- existing backoff behavior using FakeTimeProvider instead of wall-clock delays

Also converted the existing `BackOffStrategyTests` wait-based cases to advance fake time deterministically, reducing the focused test runtime from seconds to milliseconds.

## Before

<img width="1045" height="258" alt="image" src="https://github.com/user-attachments/assets/0a1d3cde-5b72-483a-b112-72a46e0645e1" />

## After

<img width="1045" height="258" alt="image" src="https://github.com/user-attachments/assets/ed2502ba-937b-4a41-a9c4-59ec695b880e" />
