### PR TITLE
Mark message-driven pub/sub compatibility mode as obsolete

### DIFF
--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiCatalog/When_custom_catalog_configured_for_legacy_publisher.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiCatalog/When_custom_catalog_configured_for_legacy_publisher.cs
@@ -61,8 +61,11 @@ public class When_custom_catalog_configured_for_legacy_publisher : MultiCatalogA
             EndpointSetup(new CustomizedServer(transport), (c, rd) =>
             {
                 var routing = c.ConfigureRouting();
+#pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 routing.EnableMessageDrivenPubSubCompatibilityMode()
                     .RegisterPublisher(typeof(Event), PublisherEndpoint);
+#pragma warning restore CS0618 // Type or member is obsolete
                 routing.UseCatalogForEndpoint(PublisherEndpoint, "nservicebus1");
             });
         }

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_for_legacy_publisher.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/MultiSchema/When_custom_schema_configured_for_legacy_publisher.cs
@@ -64,8 +64,11 @@ public class When_custom_schema_configured_for_legacy_publisher : NServiceBusAcc
                 transport.DefaultSchema = "receiver";
                 transport.Subscriptions.SubscriptionTableName = new SubscriptionTableName("SubscriptionRouting", "dbo");
 
+#pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode().RegisterPublisher(typeof(Event),
                     AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(LegacyPublisher)));
+#pragma warning restore CS0618 // Type or member is obsolete
                 c.ConfigureRouting().UseSchemaForEndpoint(publisherEndpoint, "sender");
             });
 

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -57,7 +57,10 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When((session, ctx) => session.Publish(new MyEvent()));
             })
@@ -88,7 +91,10 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When(c => c is { SubscribedMessageDriven: true, SubscribedNative: true }, (session, _) => session.Publish(new MyEvent()));
             })
@@ -96,7 +102,10 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     var compatModeSettings = new SubscriptionMigrationModeSettings(c.GetSettings());
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 });

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -67,7 +67,10 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     var compatModeSettings = new SubscriptionMigrationModeSettings(c.GetSettings());
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 });
@@ -92,7 +95,10 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When(c => c is { SubscribedMessageDriven: true, SubscribedNative: true }, (session, ctx) => session.Publish(new MyEvent()));
             })
@@ -100,7 +106,10 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     var compatModeSettings = new SubscriptionMigrationModeSettings(c.GetSettings());
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 });

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
@@ -38,7 +38,10 @@ public class When_publisher_runs_in_compat_mode : NServiceBusAcceptanceTest
         public MigratedPublisher() =>
             EndpointSetup<DefaultPublisher>(c =>
             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 c.OnEndpointSubscribed<Context>((s, context) =>
                 {
                     if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))

--- a/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SqlServer.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
@@ -51,7 +51,10 @@ public class When_subscriber_runs_in_compat_mode : NServiceBusAcceptanceTest
         public MigratedSubscriber() =>
             EndpointSetup<DefaultServer>(c =>
             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 var compatMode = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 compatMode.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 c.DisableFeature<AutoSubscribe>();
             });

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -17,6 +17,9 @@ namespace NServiceBus
     public static class MessageDrivenPubSubCompatibilityModeConfiguration
     {
         public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.RoutingSettings routingSettings) { }
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +
+            ".", false)]
         public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqlServerTransport> transportExtensions) { }
     }
     public static class PublishOptionsExtensions

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -16,6 +16,9 @@ namespace NServiceBus
     }
     public static class MessageDrivenPubSubCompatibilityModeConfiguration
     {
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +
+            ".", false)]
         public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.RoutingSettings routingSettings) { }
         [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
             "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +

--- a/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
@@ -307,11 +307,12 @@ namespace NServiceBus
         /// Enables compatibility with endpoints running on message-driven pub-sub
         /// </summary>
         /// <param name="transportExtensions">The transport to enable pub-sub compatibility on</param>
-        [PreObsolete("https://github.com/Particular/NServiceBus/issues/6471",
-               Note = "Hybrid pub/sub support cannot be obsolete until there is a viable migration path to native pub/sub",
-               Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead")]
+        [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+        [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
+            TreatAsErrorFromVersion = "10.0.0",
+            RemoveInVersion = "11.0.0")]
         public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(
-            this TransportExtensions<SqlServerTransport> transportExtensions)
+                this TransportExtensions<SqlServerTransport> transportExtensions)
         {
             var subscriptionMigrationModeSettings = transportExtensions.Routing().EnableMessageDrivenPubSubCompatibilityMode();
 

--- a/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
@@ -312,7 +312,7 @@ namespace NServiceBus
             TreatAsErrorFromVersion = "10.0.0",
             RemoveInVersion = "11.0.0")]
         public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(
-                this TransportExtensions<SqlServerTransport> transportExtensions)
+            this TransportExtensions<SqlServerTransport> transportExtensions)
         {
             var subscriptionMigrationModeSettings = transportExtensions.Routing().EnableMessageDrivenPubSubCompatibilityMode();
 

--- a/src/NServiceBus.Transport.SqlServer/PubSub/MessageDrivenPubSubCompatibilityModeConfiguration.cs
+++ b/src/NServiceBus.Transport.SqlServer/PubSub/MessageDrivenPubSubCompatibilityModeConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
+    using System;
     using Configuration.AdvancedExtensibility;
+    using Particular.Obsoletes;
 
     /// <summary>
     /// Configuration extensions for Message-Driven Pub-Sub compatibility mode
@@ -11,6 +13,10 @@
         ///     Enables compatibility with endpoints running on message-driven pub-sub
         /// </summary>
         /// <param name="routingSettings">The transport to enable pub-sub compatibility on</param>
+        [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+        [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
+            TreatAsErrorFromVersion = "10.0.0",
+            RemoveInVersion = "11.0.0")]
         public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(
             this RoutingSettings routingSettings)
         {


### PR DESCRIPTION
All uses of `EnableMessageDrivenPubSubCompatibilityMode` need to be marked as obsolete with a warning starting in the next minor version.

This also adds the `#pragma warning disable/restore` directives for tests only.