### PR TITLE
Deprecate no-op queue peek batch size (MaxRecordsToPeek / peekBatchSize)

### DIFF
--- a/src/NServiceBus.Transport.PostgreSql.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.PostgreSql.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -43,6 +43,9 @@ namespace NServiceBus
     public class QueuePeekerOptions
     {
         public System.TimeSpan Delay { get; set; }
+        [System.Obsolete("The queue peek batch size has no effect and should be removed from the configurat" +
+            "ion. Will be treated as an error from version 10.0.0. Will be removed in version" +
+            " 11.0.0.", false)]
         public int? MaxRecordsToPeek { get; set; }
     }
     public class TransactionScopeOptions

--- a/src/NServiceBus.Transport.PostgreSql.UnitTests/LegacyApiTests.cs
+++ b/src/NServiceBus.Transport.PostgreSql.UnitTests/LegacyApiTests.cs
@@ -13,7 +13,7 @@
             var transport = configuration.UseTransport<PostgreSqlTransport>();
             transport.ConnectionString("connectionString");
             transport.DefaultSchema("schema");
-            transport.QueuePeekerOptions(TimeSpan.FromSeconds(1), 100);
+            transport.QueuePeekerOptions(TimeSpan.FromSeconds(1));
 
             var nativeDelayedDelivery = transport.NativeDelayedDelivery();
             nativeDelayedDelivery.TableSuffix("suffix");
@@ -29,7 +29,6 @@
                 Assert.That(transport.Transport.ConnectionString, Is.EqualTo("connectionString"));
                 Assert.That(transport.Transport.DefaultSchema, Is.EqualTo("schema"));
                 Assert.That(transport.Transport.QueuePeeker.Delay, Is.EqualTo(TimeSpan.FromSeconds(1)));
-                Assert.That(transport.Transport.QueuePeeker.MaxRecordsToPeek, Is.EqualTo(100));
 
                 Assert.That(transport.Transport.DelayedDelivery.TableSuffix, Is.EqualTo("suffix"));
                 Assert.That(transport.Transport.DelayedDelivery.BatchSize, Is.EqualTo(100));

--- a/src/NServiceBus.Transport.PostgreSql/Configuration/PostgreSqlTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Configuration/PostgreSqlTransportSettingsExtensions.cs
@@ -181,7 +181,13 @@ namespace NServiceBus
                 transportExtensions.Transport.QueuePeeker.Delay = delay.Value;
             }
 
-            transportExtensions.Transport.QueuePeeker.MaxRecordsToPeek = peekBatchSize;
+            if (peekBatchSize.HasValue)
+            {
+                // Assigning a value logs a warning that the peek batch size has no effect.
+#pragma warning disable CS0618 // Type or member is obsolete
+                transportExtensions.Transport.QueuePeeker.MaxRecordsToPeek = peekBatchSize;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
 
             return transportExtensions;
         }

--- a/src/NServiceBus.Transport.PostgreSql/Configuration/QueuePeekerOptions.cs
+++ b/src/NServiceBus.Transport.PostgreSql/Configuration/QueuePeekerOptions.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using Logging;
+    using Particular.Obsoletes;
 
     /// <summary>
     /// Queue peeker options.
@@ -39,6 +40,11 @@ namespace NServiceBus
         /// <summary>
         /// Maximal number of records to peek.
         /// </summary>
+        [ObsoleteMetadata(
+            Message = "The queue peek batch size has no effect and should be removed from the configuration",
+            TreatAsErrorFromVersion = "10",
+            RemoveInVersion = "11")]
+        [Obsolete("The queue peek batch size has no effect and should be removed from the configuration. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
         public int? MaxRecordsToPeek
         {
             get;
@@ -48,6 +54,11 @@ namespace NServiceBus
                 {
                     var message = "Peek batch size is invalid. The value must be greater than zero.";
                     throw new Exception(message);
+                }
+
+                if (value.HasValue)
+                {
+                    Logger.Warn("Configuring the queue peek batch size (MaxRecordsToPeek) has no effect and will be removed in a future version. The number of messages received per peek is bounded by the configured message processing concurrency, and the receive loop stops as soon as the queue is drained.");
                 }
 
                 field = value;

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -27,6 +27,9 @@ namespace NServiceBus
     public class QueuePeekerOptions
     {
         public System.TimeSpan Delay { get; set; }
+        [System.Obsolete("The queue peek batch size has no effect and should be removed from the configurat" +
+            "ion. Will be treated as an error from version 10.0.0. Will be removed in version" +
+            " 11.0.0.", false)]
         public int? MaxRecordsToPeek { get; set; }
     }
     public static class SendOptionsExtensions

--- a/src/NServiceBus.Transport.SqlServer.UnitTests/LegacyApiTests.cs
+++ b/src/NServiceBus.Transport.SqlServer.UnitTests/LegacyApiTests.cs
@@ -14,7 +14,7 @@ public class LegacyApiTests
         transport.ConnectionString("connectionString");
         transport.DefaultSchema("schema");
         transport.PurgeExpiredMessagesOnStartup(100);
-        transport.QueuePeekerOptions(TimeSpan.FromSeconds(1), 100);
+        transport.QueuePeekerOptions(TimeSpan.FromSeconds(1));
 
         var nativeDelayedDelivery = transport.NativeDelayedDelivery();
         nativeDelayedDelivery.TableSuffix("suffix");
@@ -32,7 +32,6 @@ public class LegacyApiTests
             Assert.That(transport.Transport.ExpiredMessagesPurger.PurgeOnStartup, Is.EqualTo(true));
             Assert.That(transport.Transport.ExpiredMessagesPurger.PurgeBatchSize, Is.EqualTo(100));
             Assert.That(transport.Transport.QueuePeeker.Delay, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(transport.Transport.QueuePeeker.MaxRecordsToPeek, Is.EqualTo(100));
 
             Assert.That(transport.Transport.DelayedDelivery.TableSuffix, Is.EqualTo("suffix"));
             Assert.That(transport.Transport.DelayedDelivery.BatchSize, Is.EqualTo(100));

--- a/src/NServiceBus.Transport.SqlServer/Configuration/QueuePeekerOptions.cs
+++ b/src/NServiceBus.Transport.SqlServer/Configuration/QueuePeekerOptions.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using Logging;
+    using Particular.Obsoletes;
 
     /// <summary>
     /// Queue peeker options.
@@ -39,6 +40,11 @@ namespace NServiceBus
         /// <summary>
         /// Maximal number of records to peek.
         /// </summary>
+        [ObsoleteMetadata(
+            Message = "The queue peek batch size has no effect and should be removed from the configuration",
+            TreatAsErrorFromVersion = "10",
+            RemoveInVersion = "11")]
+        [Obsolete("The queue peek batch size has no effect and should be removed from the configuration. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
         public int? MaxRecordsToPeek
         {
             get;
@@ -48,6 +54,11 @@ namespace NServiceBus
                 {
                     var message = "Peek batch size is invalid. The value must be greater than zero.";
                     throw new Exception(message);
+                }
+
+                if (value.HasValue)
+                {
+                    Logger.Warn("Configuring the queue peek batch size (MaxRecordsToPeek) has no effect and will be removed in a future version. The number of messages received per peek is bounded by the configured message processing concurrency, and the receive loop stops as soon as the queue is drained.");
                 }
 
                 field = value;

--- a/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.SqlServer/Configuration/SqlServerTransportSettingsExtensions.cs
@@ -241,7 +241,13 @@ namespace NServiceBus
                 transportExtensions.Transport.QueuePeeker.Delay = delay.Value;
             }
 
-            transportExtensions.Transport.QueuePeeker.MaxRecordsToPeek = peekBatchSize;
+            if (peekBatchSize.HasValue)
+            {
+                // Assigning a value logs a warning that the peek batch size has no effect.
+#pragma warning disable CS0618 // Type or member is obsolete
+                transportExtensions.Transport.QueuePeeker.MaxRecordsToPeek = peekBatchSize;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
 
             return transportExtensions;
         }


### PR DESCRIPTION
Resolves #1754.

Marks `MaxRecordsToPeek` (and the legacy `QueuePeekerOptions` `peekBatchSize` argument) `[PreObsolete]` and logs a warning when set, stating the API has no effect. Applies to the SQL Server and PostgreSQL transports.